### PR TITLE
add support for passing headers to MapOverlay image

### DIFF
--- a/docs/overlay.md
+++ b/docs/overlay.md
@@ -22,3 +22,10 @@ type LatLng = [
   longitude: Number,
 ]
 ```
+
+```
+type ImageSource = {
+  uri?: string;
+  headers?: { [key: string]: string };
+}
+```

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapOverlay.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapOverlay.java
@@ -13,6 +13,7 @@ import com.google.android.gms.maps.model.GroundOverlayOptions;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.LatLngBounds;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 
 public class AirMapOverlay extends AirMapFeature implements ImageReadable {
@@ -57,8 +58,8 @@ public class AirMapOverlay extends AirMapFeature implements ImageReadable {
   //     }
   // }
 
-  public void setImage(String uri) {
-    this.mImageReader.setImage(uri);
+  public void setImage(String uri, @Nullable ReadableMap headers) {
+    this.mImageReader.setImage(uri, headers);
   }
 
   public void setTappable(boolean tapabble) {

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapOverlayManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapOverlayManager.java
@@ -7,6 +7,7 @@ import android.view.WindowManager;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
@@ -57,8 +58,14 @@ public class AirMapOverlayManager extends ViewGroupManager<AirMapOverlay> {
   // }
 
   @ReactProp(name = "image")
-  public void setImage(AirMapOverlay view, @Nullable String source) {
-    view.setImage(source);
+  public void setImage(AirMapOverlay view, @Nullable ReadableMap source) {
+    ReadableMap headers = null;
+    String image = null;
+    if(source != null){
+      headers = source.hasKey("headers") ? source.getMap("headers") : null;
+      image = source.getString("uri");
+    }
+    view.setImage(image, headers);
   }
 
   @ReactProp(name = "tappable", defaultBoolean = false)

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/ImageReader.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/ImageReader.java
@@ -23,6 +23,8 @@ import com.facebook.imagepipeline.image.CloseableStaticBitmap;
 import com.facebook.imagepipeline.image.ImageInfo;
 import com.facebook.imagepipeline.request.ImageRequest;
 import com.facebook.imagepipeline.request.ImageRequestBuilder;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.modules.fresco.ReactNetworkImageRequest;
 import com.google.android.gms.maps.model.BitmapDescriptor;
 import com.google.android.gms.maps.model.BitmapDescriptorFactory;
 
@@ -84,16 +86,17 @@ public class ImageReader {
         .build();
   }
 
-  public void setImage(String uri) {
+  public void setImage(String uri, @Nullable ReadableMap headers) {
     if (uri == null) {
       imp.setIconBitmapDescriptor(null);
       imp.update();
     } else if (uri.startsWith("http://") || uri.startsWith("https://") ||
         uri.startsWith("file://") || uri.startsWith("asset://")) {
-      ImageRequest imageRequest = ImageRequestBuilder
-          .newBuilderWithSource(Uri.parse(uri))
-          .build();
+      ImageRequestBuilder imageRequestBuilder = ImageRequestBuilder.newBuilderWithSource(Uri.parse(uri));
       ImagePipeline imagePipeline = Fresco.getImagePipeline();
+
+      ImageRequest imageRequest = ReactNetworkImageRequest.fromBuilderWithHeaders(imageRequestBuilder, headers);
+
       dataSource = imagePipeline.fetchDecodedImage(imageRequest, this);
 
       DraweeController controller = Fresco.newDraweeControllerBuilder()

--- a/lib/components/MapOverlay.js
+++ b/lib/components/MapOverlay.js
@@ -30,16 +30,12 @@ const propTypes = {
 
 class MapOverlay extends Component {
   render() {
-    let image;
-    if (this.props.image) {
-      if (
-        typeof this.props.image.startsWith === 'function' &&
-        this.props.image.startsWith('http')
-      ) {
-        image = this.props.image;
+    let image = this.props.image;
+    if (image) {
+      if (typeof image === 'string') {
+        image = { uri: this.props.image };
       } else {
-        image = Image.resolveAssetSource(this.props.image) || {};
-        image = image.uri;
+        image = Image.resolveAssetSource(this.props.image);
       }
     }
 

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapOverlay.h
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapOverlay.h
@@ -9,13 +9,14 @@
 #import <Foundation/Foundation.h>
 #import <GoogleMaps/GoogleMaps.h>
 #import <React/RCTBridge.h>
+#import <React/RCTImageSource.h>
 #import "AIRMapCoordinate.h"
 #import "AIRGoogleMap.h"
 
 @interface AIRGoogleMapOverlay : UIView
 
 @property (nonatomic, strong) GMSGroundOverlay *overlay;
-@property (nonatomic, copy) NSString *imageSrc;
+@property (nonatomic, copy) RCTImageSource *imageSrc;
 @property (nonatomic, strong, readonly) UIImage *overlayImage;
 @property (nonatomic, copy) NSArray *boundsRect;
 @property (nonatomic, readonly) GMSCoordinateBounds *overlayBounds;

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapOverlay.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapOverlay.m
@@ -9,6 +9,7 @@
 
 #import <React/RCTEventDispatcher.h>
 #import <React/RCTImageLoader.h>
+#import <React/RCTImageSource.h>
 #import <React/RCTUtils.h>
 #import <React/UIView+React.h>
 
@@ -31,34 +32,38 @@
   return self;
 }
 
-- (void)setImageSrc:(NSString *)imageSrc
+- (void)setImageSrc:(RCTImageSource *)imageSrc
 {
-  NSLog(@">>> SET IMAGESRC: %@", imageSrc);
-  _imageSrc = imageSrc;
+    NSLog(@">>> SET IMAGESRC: %@", imageSrc.request.URL.absoluteString);
 
-  if (_reloadImageCancellationBlock) {
-    _reloadImageCancellationBlock();
-    _reloadImageCancellationBlock = nil;
-  }
-
-  __weak typeof(self) weakSelf = self;
-  _reloadImageCancellationBlock = [_bridge.imageLoader loadImageWithURLRequest:[RCTConvert NSURLRequest:_imageSrc]
-                                                                          size:weakSelf.bounds.size
-                                                                         scale:RCTScreenScale()
-                                                                       clipped:YES
-                                                                    resizeMode:RCTResizeModeCenter
-                                                                 progressBlock:nil
-                                                              partialLoadBlock:nil
-                                                               completionBlock:^(NSError *error, UIImage *image) {
-                                                                 if (error) {
-                                                                   NSLog(@"%@", error);
-                                                                 }
-                                                                 dispatch_async(dispatch_get_main_queue(), ^{
-                                                                   NSLog(@">>> IMAGE: %@", image);
-                                                                   weakSelf.overlayImage = image;
-                                                                   weakSelf.overlay.icon = image;
-                                                                 });
-                                                               }];
+    if (![imageSrc isEqual:_imageSrc]) {
+        _imageSrc = imageSrc;
+        
+        if (_reloadImageCancellationBlock) {
+            _reloadImageCancellationBlock();
+            _reloadImageCancellationBlock = nil;
+        }
+        
+        __weak typeof(self) weakSelf = self;
+        _reloadImageCancellationBlock = [_bridge.imageLoader loadImageWithURLRequest:_imageSrc.request
+                                                                                size:weakSelf.bounds.size
+                                                                               scale:RCTScreenScale()
+                                                                             clipped:YES
+                                                                          resizeMode:RCTResizeModeCenter
+                                                                       progressBlock:nil
+                                                                    partialLoadBlock:nil
+                                                                     completionBlock:^(NSError *error, UIImage *image) {
+                                                                         if (error) {
+                                                                             NSLog(@"%@", error);
+                                                                         }
+                                                                         dispatch_async(dispatch_get_main_queue(), ^{
+                                                                             NSLog(@">>> IMAGE: %@", image);
+                                                                             weakSelf.overlayImage = image;
+                                                                             weakSelf.overlay.icon = image;
+                                                                         });
+                                                                     }];
+        
+    }
 
 }
 

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapOverlayManager.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapOverlayManager.m
@@ -1,6 +1,8 @@
 #import "AIRGoogleMapOverlayManager.h"
 #import "AIRGoogleMapOverlay.h"
 
+#import <React/RCTImageSource.h>
+
 @interface AIRGoogleMapOverlayManager()
 
 @end
@@ -17,6 +19,6 @@ RCT_EXPORT_MODULE()
 }
 
 RCT_REMAP_VIEW_PROPERTY(bounds, boundsRect, NSArray)
-RCT_REMAP_VIEW_PROPERTY(image, imageSrc, NSString)
+RCT_REMAP_VIEW_PROPERTY(image, imageSrc, RCTImageSource)
 
 @end

--- a/lib/ios/AirMaps/AIRMapOverlay.h
+++ b/lib/ios/AirMaps/AIRMapOverlay.h
@@ -5,6 +5,7 @@
 
 #import "RCTConvert+AirMap.h"
 #import <React/RCTComponent.h>
+#import <React/RCTImageSource.h>
 #import "AIRMap.h"
 #import "AIRMapOverlayRenderer.h"
 
@@ -17,7 +18,7 @@
 @property (nonatomic, weak) RCTBridge *bridge;
 
 @property (nonatomic, strong) NSString *name;
-@property (nonatomic, copy) NSString *imageSrc;
+@property (nonatomic, copy) RCTImageSource *imageSrc;
 @property (nonatomic, strong, readonly) UIImage *overlayImage;
 @property (nonatomic, copy) NSArray *boundsRect;
 @property (nonatomic, assign) NSInteger rotation;

--- a/lib/ios/AirMaps/AIRMapOverlayManager.m
+++ b/lib/ios/AirMaps/AIRMapOverlayManager.m
@@ -3,6 +3,7 @@
 #import <React/RCTConvert+CoreLocation.h>
 #import <React/RCTUIManager.h>
 #import <React/UIView+React.h>
+#import <React/RCTImageSource.h>
 #import "AIRMapOverlay.h"
 
 @interface AIRMapOverlayManager () <MKMapViewDelegate>
@@ -21,7 +22,7 @@ RCT_EXPORT_MODULE()
 }
 
 RCT_REMAP_VIEW_PROPERTY(bounds, boundsRect, NSArray)
-RCT_REMAP_VIEW_PROPERTY(image, imageSrc, NSString)
+RCT_REMAP_VIEW_PROPERTY(image, imageSrc, RCTImageSource)
 
 @end
 


### PR DESCRIPTION
<!--
PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.

**What happens if you SKIP this step?**

Your pull request will NOT be evaluated!

PLEASE NOTE THAT PRs WITHOUT THE TEMPLATE IN PLACE WILL BE CLOSED RIGHT FROM THE START.

Thanks for helping us help you!
-->

### Does any other open PR do the same thing?

<!--
**Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**

If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)
 -->

No

### What issue is this PR fixing?

Adds support for passing `headers` object to `Overlay` `image` to be able to send along HTTP headers with requests for a remote image.

### How did you test this PR?

<!--
Please let us know how you have verified that your changes work.

Ideally, your PR should contain a step-by-step test plan, so that reviewers can easily verify your changes.

Your PR will have much better chances of being merged if it is straightforward to verify.

Some questions you might want to think about:

- Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any?
- Did you test this on a real device, or in a simulator?
- Are there any platforms you were not able to test?
-->

Tested with emulator and physical device on Android and simulator on iOS. 

Things I've tested:
- passing `image` as `string` instead of `ImageURISource`
- passing local (`require`) images
- passing `image` as `ImageURISource` without headers
- passing `image` as `ImageURISource` with headers (loading an image from an API which needs an api key)

<!--
Thanks for your contribution :)
-->
