### PR TITLE
Added support for overlay rotations in Google Maps API

### DIFF
--- a/docs/overlay.md
+++ b/docs/overlay.md
@@ -6,9 +6,9 @@
 |---|---|---|---|
 | `image` | `ImageSource` | A custom image to be used as the overlay. Only required local image resources and uri (as for images located in the net) are allowed to be used.
 | `bounds` | `Array<LatLng>` |  | The coordinates for the image (left-top corner, right-bottom corner). ie.```[[lat, long], [lat, long]]```
-| `bearing` | `Float` | `0` | The bearing in degrees clockwise from north. Values outside the range [0, 360) will be normalized.
+| `bearing` | `Float` | `0` | `Google Maps API only` The bearing in degrees clockwise from north. Values outside the range [0, 360) will be normalized.
 | `tappable` | `Bool` | `false` | `Android only` Boolean to allow an overlay to be tappable and use the onPress function.
-| `location` | `[Float, Float]` |  | `Android only` Location of the anchor point.
+| `location` | `[Float, Float]` |  | `Android only` Location of the image overlay.
 | `width` | `Float` |  | `Android only` The width of the overlay (in meters).
 | `height` | `Float` |  | `Android only` The height of the overlay (in meters).
 | `anchor` | `[Float, Float]` |  | `Android only` Anchor point is specified in 2D continuous space where [0, 0], [1, 0], [0, 1] and [1, 1] denote the top-left, top-right, bottom-left and bottom-right corners respectively.
@@ -29,5 +29,7 @@ type LatLng = [
 ```
 ## Android only - Specifying overlay location
 There are two ways to specify the position of the overlay in `Android`:
-Using a location: You must provide an image of the overlay, a LatLng to which the anchor will be fixed and the width of the overlay (in meters). The anchor is, by default, 50% from the top of the image and 50% from the left of the image. This can be changed. You can optionally provide the height of the overlay (in meters). If you do not provide the height of the overlay, it will be automatically calculated to preserve the proportions of the image.
-Using a Bounds: You must provide a `Array<LatLng>` which will contain the image's left-top corner, right-bottom corner.
+
+**Using a location:** You must provide an image of the overlay, a LatLng to which the anchor will be fixed and the width of the overlay (in meters). The anchor is, by default, 50% from the top of the image and 50% from the left of the image. This can be changed. You can optionally provide the height of the overlay (in meters). If you do not provide the height of the overlay, it will be automatically calculated to preserve the proportions of the image.
+
+**Using a Bounds:** You must provide a `Array<LatLng>` which will contain the image's left-top corner, right-bottom corner.

--- a/docs/overlay.md
+++ b/docs/overlay.md
@@ -6,7 +6,12 @@
 |---|---|---|---|
 | `image` | `ImageSource` | A custom image to be used as the overlay. Only required local image resources and uri (as for images located in the net) are allowed to be used.
 | `bounds` | `Array<LatLng>` |  | The coordinates for the image (left-top corner, right-bottom corner). ie.```[[lat, long], [lat, long]]```
+| `bearing` | `Float` | `0` | The bearing in degrees clockwise from north. Values outside the range [0, 360) will be normalized.
 | `tappable` | `Bool` | `false` | `Android only` Boolean to allow an overlay to be tappable and use the onPress function.
+| `location` | `[Float, Float]` |  | `Android only` Location of the anchor point.
+| `width` | `Float` |  | `Android only` The width of the overlay (in meters).
+| `height` | `Float` |  | `Android only` The height of the overlay (in meters).
+| `anchor` | `[Float, Float]` |  | `Android only` Anchor point is specified in 2D continuous space where [0, 0], [1, 0], [0, 1] and [1, 1] denote the top-left, top-right, bottom-left and bottom-right corners respectively.
 
 ## Events
 
@@ -22,3 +27,7 @@ type LatLng = [
   longitude: Number,
 ]
 ```
+## Android only - Specifying overlay location
+There are two ways to specify the position of the overlay in `Android`:
+Using a location: You must provide an image of the overlay, a LatLng to which the anchor will be fixed and the width of the overlay (in meters). The anchor is, by default, 50% from the top of the image and 50% from the left of the image. This can be changed. You can optionally provide the height of the overlay (in meters). If you do not provide the height of the overlay, it will be automatically calculated to preserve the proportions of the image.
+Using a Bounds: You must provide a `Array<LatLng>` which will contain the image's left-top corner, right-bottom corner.

--- a/example/examples/ImageOverlayWithRotation.js
+++ b/example/examples/ImageOverlayWithRotation.js
@@ -1,0 +1,60 @@
+import React, { Component } from 'react';
+import { StyleSheet, View } from 'react-native';
+import MapView from 'react-native-maps';
+
+const LATITUDE = 23.117546;
+const LONGITUDE = -82.368373;
+const URL = 'https://www.gstatic.com/webp/gallery/2.jpg';
+const REGION = {
+  latitude: LATITUDE,
+  longitude: LONGITUDE,
+  latitudeDelta: 0.005,
+  longitudeDelta: 0.005,
+};
+
+export default class ImageOverlayWithRotation extends Component {
+  static propTypes = {
+    provider: MapView.ProviderPropType,
+  };
+
+  render() {
+    return (
+      <View style={styles.container}>
+        <MapView
+          provider={this.props.provider}
+          style={styles.map}
+          initialRegion={REGION}
+        >
+          <MapView.Overlay
+            key={'0'}
+            image={{ uri: URL }}
+            location={[LATITUDE, LONGITUDE]}
+            width={300}
+            anchor={[0.5, 0.5]}
+            bearing={-30}
+          />
+          <MapView.Overlay
+            key={'1'}
+            image={{ uri: URL }}
+            location={[LATITUDE, LONGITUDE]}
+            width={300}
+            height={100}
+            anchor={[1, 1]}
+            bearing={30}
+          />
+        </MapView>
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+  },
+  map: {
+    ...StyleSheet.absoluteFillObject,
+  },
+});

--- a/index.d.ts
+++ b/index.d.ts
@@ -476,11 +476,17 @@ declare module "react-native-maps" {
   // =======================================================================
 
   type Coordinate = [number, number];
+  type Anchor = [number, number]
 
   export interface MapOverlayProps extends ViewProperties {
     image?: ImageURISource | ImageRequireSource;
-    bounds: [Coordinate, Coordinate];
+    bounds?: [Coordinate, Coordinate];
     tappable?: boolean;
+    location?: Coordinate;
+    width?: number;
+    height?: number;
+    anchor?: Anchor;
+    bearing?: number;
     onPress?: (event: MapEvent<{ action: "overlay-press"; }>) => void;
   }
 

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapOverlay.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapOverlay.java
@@ -25,6 +25,12 @@ public class AirMapOverlay extends AirMapFeature implements ImageReadable {
   private boolean tappable;
   private float zIndex;
   private float transparency;
+  private LatLng location;
+  private float width;
+  private float height;
+  private float bearing;
+  private float[] anchor;
+
 
   private final ImageReader mImageReader;
   private GoogleMap map;
@@ -41,6 +47,26 @@ public class AirMapOverlay extends AirMapFeature implements ImageReadable {
     if (this.groundOverlay != null) {
       this.groundOverlay.setPositionFromBounds(this.bounds);
     }
+  }
+
+  public void setLocation(ReadableArray location){
+    this.location = new LatLng(location.getDouble(0), location.getDouble(1));
+  }
+
+  public void setWidth(float width) {
+    this.width = width;
+  }
+
+  public void setHeight(float height) {
+    this.height = height;
+  }
+
+  public void setBearing(float bearing){
+    this.bearing = bearing;
+  }
+
+  public void setAnchor(ReadableArray anchor){
+    this.anchor = new float[]{ (float)anchor.getDouble(0) , (float)anchor.getDouble(1) };
   }
 
   public void setZIndex(float zIndex) {
@@ -81,6 +107,7 @@ public class AirMapOverlay extends AirMapFeature implements ImageReadable {
       return this.groundOverlayOptions;
     }
     GroundOverlayOptions options = new GroundOverlayOptions();
+
     if (this.iconBitmapDescriptor != null) {
       options.image(iconBitmapDescriptor);
     } else {
@@ -90,7 +117,20 @@ public class AirMapOverlay extends AirMapFeature implements ImageReadable {
       // hide overlay until real image gets added
       options.visible(false);
     }
-    options.positionFromBounds(bounds);
+
+    // Two different ways of specifying postion of the groundOverlay
+    if(this.location != null){
+      if(this.height == 0.0f){
+        options.position(location, width);
+      } else {
+        options.position(location, width, height);
+      }
+      options.anchor(anchor[0], anchor[1]);
+      options.bearing(bearing);
+    } else {
+      options.positionFromBounds(bounds);
+    }
+
     options.zIndex(zIndex);
     return options;
   }

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapOverlayManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapOverlayManager.java
@@ -11,6 +11,7 @@ import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
+import com.google.android.gms.maps.model.LatLng;
 
 import java.util.Map;
 
@@ -46,6 +47,31 @@ public class AirMapOverlayManager extends ViewGroupManager<AirMapOverlay> {
     view.setBounds(bounds);
   }
 
+  @ReactProp(name = "location")
+  public void setLocation(AirMapOverlay view, ReadableArray location){
+    view.setLocation(location);
+  }
+
+  @ReactProp(name = "width")
+  public void setWidth(AirMapOverlay view, float width) {
+    view.setWidth(width);
+  }
+
+  @ReactProp(name = "height")
+  public void setHeight(AirMapOverlay view, float height) {
+    view.setHeight(height);
+  }
+
+  @ReactProp(name = "bearing")
+  public void setBearing(AirMapOverlay view, float bearing){
+    view.setBearing(bearing);
+  }
+
+  @ReactProp(name = "anchor")
+  public void setAnchor(AirMapOverlay view, ReadableArray anchor){
+    view.setAnchor(anchor);
+  }
+  
   @ReactProp(name = "zIndex", defaultFloat = 1.0f)
   public void setZIndex(AirMapOverlay view, float zIndex) {
     view.setZIndex(zIndex);

--- a/lib/components/MapOverlay.js
+++ b/lib/components/MapOverlay.js
@@ -19,7 +19,19 @@ const propTypes = {
   // A custom image to be used as overlay.
   image: PropTypes.any.isRequired,
   // Top left and bottom right coordinates for the overlay
-  bounds: PropTypes.arrayOf(PropTypes.array.isRequired).isRequired,
+  bounds: PropTypes.arrayOf(PropTypes.array.isRequired),
+  // Location of the image
+  location: PropTypes.any,
+  // The width of the overlay (in meters).
+  width: PropTypes.number,
+  // The height of the overlay (in meters).
+  height: PropTypes.number,
+  /* Anchor point is specified in 2D continuous space where (0,0), (1,0), (0,1) and (1,1)
+   * denote the top-left, top-right, bottom-left and bottom-right corners respectively.
+   */
+  anchor: PropTypes.arrayOf(PropTypes.number.isRequired),
+  // The bearing in degrees clockwise from north.
+  bearing: PropTypes.number,
   /* Boolean to allow an overlay to be tappable and use the
    * onPress function
    */

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapOverlay.h
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapOverlay.h
@@ -19,6 +19,7 @@
 @property (nonatomic, strong, readonly) UIImage *overlayImage;
 @property (nonatomic, copy) NSArray *boundsRect;
 @property (nonatomic, readonly) GMSCoordinateBounds *overlayBounds;
+@property (nonatomic, readonly) CLLocationDirection bearing;
 
 @property (nonatomic, weak) RCTBridge *bridge;
 

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapOverlay.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapOverlay.m
@@ -15,6 +15,7 @@
 @interface AIRGoogleMapOverlay()
   @property (nonatomic, strong, readwrite) UIImage *overlayImage;
   @property (nonatomic, readwrite) GMSCoordinateBounds *overlayBounds;
+  @property (nonatomic) CLLocationDirection bearing;
 @end
 
 @implementation AIRGoogleMapOverlay {
@@ -73,6 +74,12 @@
                                                         coordinate:_northEast];
 
   _overlay.bounds = _overlayBounds;
+}
+
+- (void)setBearing:(double)bearing
+{
+    _bearing = (CLLocationDirection)bearing;
+    _overlay.bearing = _bearing;
 }
 
 @end

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapOverlayManager.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapOverlayManager.m
@@ -18,5 +18,6 @@ RCT_EXPORT_MODULE()
 
 RCT_REMAP_VIEW_PROPERTY(bounds, boundsRect, NSArray)
 RCT_REMAP_VIEW_PROPERTY(image, imageSrc, NSString)
+RCT_EXPORT_VIEW_PROPERTY(bearing, double)
 
 @end


### PR DESCRIPTION

<!--
PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.

**What happens if you SKIP this step?**

Your pull request will NOT be evaluated!

PLEASE NOTE THAT PRs WITHOUT THE TEMPLATE IN PLACE WILL BE CLOSED RIGHT FROM THE START.

Thanks for helping us help you!
-->

### Does any other open PR do the same thing?
No

### What issue is this PR fixing?

[2892](https://github.com/react-native-community/react-native-maps/issues/2892)
[2850](https://github.com/react-native-community/react-native-maps/issues/2850)

### How did you test this PR?
<!--
Please let us know how you have verified that your changes work.

Ideally, your PR should contain a step-by-step test plan, so that reviewers can easily verify your changes.

Your PR will have much better chances of being merged if it is straightforward to verify.

Some questions you might want to think about:

- Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any?
- Did you test this on a real device, or in a simulator?
- Are there any platforms you were not able to test?
-->

- Created plain `MapView`
- Added an `Overlay` child view to it:
- `Android:` Verified that both methods (bounds vs location + bearing + anchor) work
- `iOS:` Verified that setting `bearing` to something different from zero, rotates the overlay.

<!--
Thanks for your contribution :)
-->
