### PR TITLE
Pass camera move's reason to JS callbacks

### DIFF
--- a/docs/mapview.md
+++ b/docs/mapview.md
@@ -56,8 +56,8 @@ To access event data, you will need to use `e.nativeEvent`. For example, `onPres
 |---|---|---|
 | `onMapReady` |  | Callback that is called once the map is fully loaded.
 | `onKmlReady` | `KmlContainer` | Callback that is called once the kml is fully loaded.
-| `onRegionChange` | `Region` | Callback that is called continuously when the region changes, such as when a user is dragging the map.
-| `onRegionChangeComplete` | `Region` | Callback that is called once when the region changes, such as when the user is done moving the map.
+| `onRegionChange` | (`Region`, `{isGesture: boolean}`) | Callback that is called continuously when the region changes, such as when a user is dragging the map. The second parameter is an object containing more details about the move. `isGesture` property indicates if the move was from the user (true) or an animation (false).
+| `onRegionChangeComplete` | (`Region`, `{isGesture: boolean}`) | Callback that is called once when the region changes, such as when the user is done moving the map.  The second parameter is an object containing more details about the move. `isGesture` property indicates if the move was from the user (true) or an animation (false).
 | `onUserLocationChange` | `{ coordinate: Location }` | Callback that is called when the underlying map figures our users current location (coordinate also includes isFromMockProvider value for Android API 18 and above). Make sure **showsUserLocation** is set to *true*.
 | `onPress` | `{ coordinate: LatLng, position: Point }` | Callback that is called when user taps on the map.
 | `onDoublePress` | `{ coordinate: LatLng, position: Point }` | Callback that is called when user double taps on the map.

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -349,8 +349,12 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
       @Override
       public void onCameraMove() {
         LatLngBounds bounds = map.getProjection().getVisibleRegion().latLngBounds;
+
         cameraLastIdleBounds = null;
-        eventDispatcher.dispatchEvent(new RegionChangeEvent(getId(), bounds, cameraMoveReason, true));
+        boolean isGesture = GoogleMap.OnCameraMoveStartedListener.REASON_GESTURE == cameraMoveReason;
+
+        RegionChangeEvent event = new RegionChangeEvent(getId(), bounds, true, isGesture);
+        eventDispatcher.dispatchEvent(event);
       }
     });
 
@@ -361,8 +365,12 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
         if ((cameraMoveReason != 0) &&
           ((cameraLastIdleBounds == null) ||
             LatLngBoundsUtils.BoundsAreDifferent(bounds, cameraLastIdleBounds))) {
+
           cameraLastIdleBounds = bounds;
-          eventDispatcher.dispatchEvent(new RegionChangeEvent(getId(), bounds, cameraMoveReason, false));
+          boolean isGesture = GoogleMap.OnCameraMoveStartedListener.REASON_GESTURE == cameraMoveReason;
+
+          RegionChangeEvent event = new RegionChangeEvent(getId(), bounds, false, isGesture);
+          eventDispatcher.dispatchEvent(event);
         }
       }
     });

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -350,7 +350,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
       public void onCameraMove() {
         LatLngBounds bounds = map.getProjection().getVisibleRegion().latLngBounds;
         cameraLastIdleBounds = null;
-        eventDispatcher.dispatchEvent(new RegionChangeEvent(getId(), bounds, true));
+        eventDispatcher.dispatchEvent(new RegionChangeEvent(getId(), bounds, cameraMoveReason, true));
       }
     });
 
@@ -362,7 +362,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
           ((cameraLastIdleBounds == null) ||
             LatLngBoundsUtils.BoundsAreDifferent(bounds, cameraLastIdleBounds))) {
           cameraLastIdleBounds = bounds;
-          eventDispatcher.dispatchEvent(new RegionChangeEvent(getId(), bounds, false));
+          eventDispatcher.dispatchEvent(new RegionChangeEvent(getId(), bounds, cameraMoveReason, false));
         }
       }
     });
@@ -872,12 +872,12 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     if (addedPosition) {
       LatLngBounds bounds = builder.build();
       CameraUpdate cu = CameraUpdateFactory.newLatLngBounds(bounds, baseMapPadding);
-      
+
       if (edgePadding != null) {
         map.setPadding(edgePadding.getInt("left"), edgePadding.getInt("top"),
           edgePadding.getInt("right"), edgePadding.getInt("bottom"));
-      }   
-      
+      }
+
       if (animated) {
         map.animateCamera(cu);
       } else {
@@ -1246,13 +1246,13 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
       indoorBuilding.putArray("levels", levelsArray);
       indoorBuilding.putInt("activeLevelIndex", 0);
       indoorBuilding.putBoolean("underground", false);
-      
+
       event.putMap("IndoorBuilding", indoorBuilding);
 
       manager.pushEvent(context, this, "onIndoorBuildingFocused", event);
     }
   }
-  
+
   @Override
   public void onIndoorLevelActivated(IndoorBuilding building) {
     if (building == null) {
@@ -1275,7 +1275,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
 
     manager.pushEvent(context, this, "onIndoorLevelActivated", event);
   }
-    
+
   public void setIndoorActiveLevelIndex(int activeLevelIndex) {
     IndoorBuilding building = this.map.getFocusedBuilding();
     if (building != null) {

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/RegionChangeEvent.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/RegionChangeEvent.java
@@ -9,14 +9,14 @@ import com.google.android.gms.maps.model.LatLngBounds;
 
 public class RegionChangeEvent extends Event<RegionChangeEvent> {
   private final LatLngBounds bounds;
-  private final int reason;
   private final boolean continuous;
+  private final boolean isGesture;
 
-  public RegionChangeEvent(int id, LatLngBounds bounds, int reason, boolean continuous) {
+  public RegionChangeEvent(int id, LatLngBounds bounds, boolean continuous, boolean isGesture) {
     super(id);
     this.bounds = bounds;
-    this.reason = reason;
     this.continuous = continuous;
+    this.isGesture = isGesture;
   }
 
   @Override
@@ -31,9 +31,7 @@ public class RegionChangeEvent extends Event<RegionChangeEvent> {
 
   @Override
   public void dispatch(RCTEventEmitter rctEventEmitter) {
-
     WritableMap event = new WritableNativeMap();
-    event.putInt("reason", reason);
     event.putBoolean("continuous", continuous);
 
     WritableMap region = new WritableNativeMap();
@@ -43,6 +41,7 @@ public class RegionChangeEvent extends Event<RegionChangeEvent> {
     region.putDouble("latitudeDelta", bounds.northeast.latitude - bounds.southwest.latitude);
     region.putDouble("longitudeDelta", bounds.northeast.longitude - bounds.southwest.longitude);
     event.putMap("region", region);
+    event.putBoolean("isGesture", isGesture);
 
     rctEventEmitter.receiveEvent(getViewTag(), getEventName(), event);
   }

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/RegionChangeEvent.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/RegionChangeEvent.java
@@ -9,11 +9,13 @@ import com.google.android.gms.maps.model.LatLngBounds;
 
 public class RegionChangeEvent extends Event<RegionChangeEvent> {
   private final LatLngBounds bounds;
+  private final int reason;
   private final boolean continuous;
 
-  public RegionChangeEvent(int id, LatLngBounds bounds, boolean continuous) {
+  public RegionChangeEvent(int id, LatLngBounds bounds, int reason, boolean continuous) {
     super(id);
     this.bounds = bounds;
+    this.reason = reason;
     this.continuous = continuous;
   }
 
@@ -31,6 +33,7 @@ public class RegionChangeEvent extends Event<RegionChangeEvent> {
   public void dispatch(RCTEventEmitter rctEventEmitter) {
 
     WritableMap event = new WritableNativeMap();
+    event.putInt("reason", reason);
     event.putBoolean("continuous", continuous);
 
     WritableMap region = new WritableNativeMap();

--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -629,12 +629,15 @@ class MapView extends React.Component {
 
   _onChange(event) {
     this.__lastRegion = event.nativeEvent.region;
+    const reason = event.nativeEvent.reason;
+    const details = {reason};
+
     if (event.nativeEvent.continuous) {
       if (this.props.onRegionChange) {
-        this.props.onRegionChange(event.nativeEvent.region);
+        this.props.onRegionChange(event.nativeEvent.region, details);
       }
     } else if (this.props.onRegionChangeComplete) {
-      this.props.onRegionChangeComplete(event.nativeEvent.region);
+      this.props.onRegionChangeComplete(event.nativeEvent.region, details);
     }
   }
 
@@ -1025,8 +1028,8 @@ if (Platform.OS === 'android') {
   airMaps.google = googleMapIsInstalled
     ? nativeComponent('AIRGoogleMap')
     : createNotSupportedComponent(
-        'react-native-maps: AirGoogleMaps dir must be added to your xCode project to support GoogleMaps on iOS.'
-      );
+      'react-native-maps: AirGoogleMaps dir must be added to your xCode project to support GoogleMaps on iOS.'
+    );
 }
 const getAirMapComponent = provider => airMaps[provider || 'default'];
 

--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -627,17 +627,17 @@ class MapView extends React.Component {
     }
   }
 
-  _onChange(event) {
-    this.__lastRegion = event.nativeEvent.region;
-    const reason = event.nativeEvent.reason;
-    const details = {reason};
+  _onChange({nativeEvent}) {
+    this.__lastRegion = nativeEvent.region;
+    const isGesture = nativeEvent.isGesture;
+    const details = {isGesture};
 
-    if (event.nativeEvent.continuous) {
+    if (nativeEvent.continuous) {
       if (this.props.onRegionChange) {
-        this.props.onRegionChange(event.nativeEvent.region, details);
+        this.props.onRegionChange(nativeEvent.region, details);
       }
     } else if (this.props.onRegionChangeComplete) {
-      this.props.onRegionChangeComplete(event.nativeEvent.region, details);
+      this.props.onRegionChangeComplete(nativeEvent.region, details);
     }
   }
 

--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -627,10 +627,10 @@ class MapView extends React.Component {
     }
   }
 
-  _onChange({nativeEvent}) {
+  _onChange({ nativeEvent }) {
     this.__lastRegion = nativeEvent.region;
     const isGesture = nativeEvent.isGesture;
-    const details = {isGesture};
+    const details = { isGesture };
 
     if (nativeEvent.continuous) {
       if (this.props.onRegionChange) {
@@ -1028,8 +1028,8 @@ if (Platform.OS === 'android') {
   airMaps.google = googleMapIsInstalled
     ? nativeComponent('AIRGoogleMap')
     : createNotSupportedComponent(
-      'react-native-maps: AirGoogleMaps dir must be added to your xCode project to support GoogleMaps on iOS.'
-    );
+        'react-native-maps: AirGoogleMaps dir must be added to your xCode project to support GoogleMaps on iOS.'
+      );
 }
 const getAirMapComponent = provider => airMaps[provider || 'default'];
 

--- a/lib/ios/AirGoogleMaps/AIRGoogleMap.h
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMap.h
@@ -69,8 +69,8 @@
 - (void)didTapPolygon:(GMSPolygon *)polygon;
 - (void)didTapAtCoordinate:(CLLocationCoordinate2D)coordinate;
 - (void)didLongPressAtCoordinate:(CLLocationCoordinate2D)coordinate;
-- (void)didChangeCameraPosition:(GMSCameraPosition *)position reason:(BOOL)reason;
-- (void)idleAtCameraPosition:(GMSCameraPosition *)position reason:(BOOL)reason;
+- (void)didChangeCameraPosition:(GMSCameraPosition *)position isGesture:(BOOL)isGesture;
+- (void)idleAtCameraPosition:(GMSCameraPosition *)position isGesture:(BOOL)isGesture;
 - (void)didTapPOIWithPlaceID:(NSString *)placeID name:(NSString *) name location:(CLLocationCoordinate2D) location;
 - (NSArray *)getMapBoundaries;
 

--- a/lib/ios/AirGoogleMaps/AIRGoogleMap.h
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMap.h
@@ -69,8 +69,8 @@
 - (void)didTapPolygon:(GMSPolygon *)polygon;
 - (void)didTapAtCoordinate:(CLLocationCoordinate2D)coordinate;
 - (void)didLongPressAtCoordinate:(CLLocationCoordinate2D)coordinate;
-- (void)didChangeCameraPosition:(GMSCameraPosition *)position;
-- (void)idleAtCameraPosition:(GMSCameraPosition *)position;
+- (void)didChangeCameraPosition:(GMSCameraPosition *)position reason:(BOOL)reason;
+- (void)idleAtCameraPosition:(GMSCameraPosition *)position reason:(BOOL)reason;
 - (void)didTapPOIWithPlaceID:(NSString *)placeID name:(NSString *) name location:(CLLocationCoordinate2D) location;
 - (NSArray *)getMapBoundaries;
 

--- a/lib/ios/AirGoogleMaps/AIRGoogleMap.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMap.m
@@ -93,7 +93,7 @@ id regionAsJSON(MKCoordinateRegion region) {
            forKeyPath:@"myLocation"
               options:NSKeyValueObservingOptionNew
               context:NULL];
-      
+
     self.origGestureRecognizersMeta = [[NSMutableDictionary alloc] init];
   }
   return self;
@@ -227,10 +227,10 @@ id regionAsJSON(MKCoordinateRegion region) {
 {
     GMSVisibleRegion visibleRegion = self.projection.visibleRegion;
     GMSCoordinateBounds *bounds = [[GMSCoordinateBounds alloc] initWithRegion:visibleRegion];
-    
+
     CLLocationCoordinate2D northEast = bounds.northEast;
     CLLocationCoordinate2D southWest = bounds.southWest;
-    
+
     return @[
         @[
             [NSNumber numberWithDouble:northEast.longitude],
@@ -290,7 +290,7 @@ id regionAsJSON(MKCoordinateRegion region) {
 - (void)didPrepareMap {
   UIView* mapView = [self valueForKey:@"mapView"]; //GMSVectorMapView
   [self overrideGestureRecognizersForView:mapView];
-    
+
   if (_didCallOnMapReady) return;
   _didCallOnMapReady = true;
   if (self.onMapReady) self.onMapReady(@{});
@@ -349,10 +349,10 @@ id regionAsJSON(MKCoordinateRegion region) {
   self.onLongPress([self eventFromCoordinate:coordinate]);
 }
 
-- (void)didChangeCameraPosition:(GMSCameraPosition *)position reason:(BOOL)reason{
+- (void)didChangeCameraPosition:(GMSCameraPosition *)position isGesture:(BOOL)isGesture{
   id event = @{@"continuous": @YES,
                @"region": regionAsJSON([AIRGoogleMap makeGMSCameraPositionFromMap:self andGMSCameraPosition:position]),
-               @"reason": [NSNumber numberWithBool:reason],
+               @"isGesture": [NSNumber numberWithBool:isGesture],
                };
 
   if (self.onChange) self.onChange(event);
@@ -372,10 +372,10 @@ id regionAsJSON(MKCoordinateRegion region) {
   if (self.onPoiClick) self.onPoiClick(event);
 }
 
-- (void)idleAtCameraPosition:(GMSCameraPosition *)position  reason:(BOOL)reason{
+- (void)idleAtCameraPosition:(GMSCameraPosition *)position  isGesture:(BOOL)isGesture{
   id event = @{@"continuous": @NO,
                @"region": regionAsJSON([AIRGoogleMap makeGMSCameraPositionFromMap:self andGMSCameraPosition:position]),
-               @"reason": [NSNumber numberWithBool:reason],
+               @"isGesture": [NSNumber numberWithBool:isGesture],
                };
   if (self.onChange) self.onChange(event);  // complete
 }
@@ -414,7 +414,7 @@ id regionAsJSON(MKCoordinateRegion region) {
       return @"automatic";
     case kGMSMapViewPaddingAdjustmentBehaviorAlways:
       return @"always";
-      
+
     default:
       return @"unknown";
   }
@@ -648,7 +648,7 @@ id regionAsJSON(MKCoordinateRegion region) {
         NSNumber* grHash = [NSNumber numberWithUnsignedInteger:gestureRecognizer.hash];
         if([self.origGestureRecognizersMeta objectForKey:grHash] != nil)
             continue; //already patched
-        
+
         //get original handlers
         NSArray* origTargets = [gestureRecognizer valueForKey:@"targets"];
         NSMutableArray* origTargetsActions = [[NSMutableArray alloc] init];
@@ -666,7 +666,7 @@ id regionAsJSON(MKCoordinateRegion region) {
             [view removeGestureRecognizer:gestureRecognizer];
             continue;
         }
-        
+
         //replace with extendedMapGestureHandler
         for (NSDictionary* origTargetAction in origTargetsActions) {
             NSValue* targetValue = [origTargetAction objectForKey:@"target"];
@@ -676,7 +676,7 @@ id regionAsJSON(MKCoordinateRegion region) {
             [gestureRecognizer removeTarget:target action:action];
         }
         [gestureRecognizer addTarget:self action:@selector(extendedMapGestureHandler:)];
-        
+
         [self.origGestureRecognizersMeta setObject:@{@"targets": origTargetsActions}
                                             forKey:grHash];
     }
@@ -689,14 +689,14 @@ id regionAsJSON(MKCoordinateRegion region) {
     CGRect bubbleAbsoluteFrame = [bubbleProvider accessibilityFrame];
     CGRect bubbleFrame = [win convertRect:bubbleAbsoluteFrame toView:self];
     UIView* bubbleView = [bubbleProvider valueForKey:@"view"];
-    
+
     BOOL performOriginalActions = YES;
     BOOL isTap = [gestureRecognizer isKindOfClass:[UITapGestureRecognizer class]] || [gestureRecognizer isMemberOfClass:[UITapGestureRecognizer class]];
     if (isTap) {
         BOOL isTapInsideBubble = NO;
     CGPoint tapPoint = CGPointZero;
     CGPoint tapPointInBubble = CGPointZero;
-    
+
     NSArray* touches = [gestureRecognizer valueForKey:@"touches"];
     UITouch* oneTouch = [touches firstObject];
     NSArray* delayedTouches = [gestureRecognizer valueForKey:@"delayedTouches"];
@@ -720,7 +720,7 @@ id regionAsJSON(MKCoordinateRegion region) {
                     break;
                 }
             }
-            
+
             //find real tap target subview
             UIView* realSubview = [(RCTView*)bubbleView hitTest:tapPointInBubble withEvent:nil];
             AIRGoogleMapCalloutSubview* realPressableSubview = nil;
@@ -734,7 +734,7 @@ id regionAsJSON(MKCoordinateRegion region) {
                     tmp = tmp.superview;
                 }
             }
-            
+
             if (markerView) {
                 BOOL isInsideCallout = [markerView.calloutView isPointInside:tapPointInBubble];
                 if (isInsideCallout) {
@@ -749,12 +749,12 @@ id regionAsJSON(MKCoordinateRegion region) {
                         [self didTapAtCoordinate:coord];
                     }
                 }
-                
+
                 performOriginalActions = NO;
             }
         }
     }
-    
+
     if (performOriginalActions) {
         NSDictionary* origMeta = [self.origGestureRecognizersMeta objectForKey:grHash];
         NSDictionary* origTargets = [origMeta objectForKey:@"targets"];
@@ -769,7 +769,7 @@ id regionAsJSON(MKCoordinateRegion region) {
 #pragma clang diagnostic pop
         }
     }
-    
+
     return nil;
 }
 

--- a/lib/ios/AirGoogleMaps/AIRGoogleMap.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMap.m
@@ -349,9 +349,10 @@ id regionAsJSON(MKCoordinateRegion region) {
   self.onLongPress([self eventFromCoordinate:coordinate]);
 }
 
-- (void)didChangeCameraPosition:(GMSCameraPosition *)position {
+- (void)didChangeCameraPosition:(GMSCameraPosition *)position reason:(BOOL)reason{
   id event = @{@"continuous": @YES,
                @"region": regionAsJSON([AIRGoogleMap makeGMSCameraPositionFromMap:self andGMSCameraPosition:position]),
+               @"reason": [NSNumber numberWithBool:reason],
                };
 
   if (self.onChange) self.onChange(event);
@@ -371,9 +372,10 @@ id regionAsJSON(MKCoordinateRegion region) {
   if (self.onPoiClick) self.onPoiClick(event);
 }
 
-- (void)idleAtCameraPosition:(GMSCameraPosition *)position {
+- (void)idleAtCameraPosition:(GMSCameraPosition *)position  reason:(BOOL)reason{
   id event = @{@"continuous": @NO,
                @"region": regionAsJSON([AIRGoogleMap makeGMSCameraPositionFromMap:self andGMSCameraPosition:position]),
+               @"reason": [NSNumber numberWithBool:reason],
                };
   if (self.onChange) self.onChange(event);  // complete
 }

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapManager.h
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapManager.h
@@ -12,6 +12,7 @@
 
 @interface AIRGoogleMapManager : RCTViewManager
 @property (nonatomic, assign) AIRGoogleMap *map;
+@property (nonatomic) BOOL reason;
 
 @end
 

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapManager.h
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapManager.h
@@ -12,7 +12,7 @@
 
 @interface AIRGoogleMapManager : RCTViewManager
 @property (nonatomic, assign) AIRGoogleMap *map;
-@property (nonatomic) BOOL reason;
+@property (nonatomic) BOOL isGesture;
 
 @end
 

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
@@ -572,6 +572,10 @@ RCT_EXPORT_METHOD(setIndoorActiveLevelIndex:(nonnull NSNumber *)reactTag
   return @{ @"legalNotice": [GMSServices openSourceLicenseInfo] };
 }
 
+- (void)mapView:(GMSMapView *)mapView willMove:(BOOL)gesture{
+    self.reason = gesture;
+}
+
 - (void)mapViewDidStartTileRendering:(GMSMapView *)mapView {
   AIRGoogleMap *googleMapView = (AIRGoogleMap *)mapView;
   [googleMapView didPrepareMap];
@@ -604,12 +608,12 @@ RCT_EXPORT_METHOD(setIndoorActiveLevelIndex:(nonnull NSNumber *)reactTag
 
 - (void)mapView:(GMSMapView *)mapView didChangeCameraPosition:(GMSCameraPosition *)position {
   AIRGoogleMap *googleMapView = (AIRGoogleMap *)mapView;
-  [googleMapView didChangeCameraPosition:position];
+  [googleMapView didChangeCameraPosition:position reason:self.reason];
 }
 
 - (void)mapView:(GMSMapView *)mapView idleAtCameraPosition:(GMSCameraPosition *)position {
   AIRGoogleMap *googleMapView = (AIRGoogleMap *)mapView;
-  [googleMapView idleAtCameraPosition:position];
+  [googleMapView idleAtCameraPosition:position reason:self.reason];
 }
 
 - (UIView *)mapView:(GMSMapView *)mapView markerInfoWindow:(GMSMarker *)marker {

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
@@ -573,7 +573,7 @@ RCT_EXPORT_METHOD(setIndoorActiveLevelIndex:(nonnull NSNumber *)reactTag
 }
 
 - (void)mapView:(GMSMapView *)mapView willMove:(BOOL)gesture{
-    self.reason = gesture;
+    self.isGesture = gesture;
 }
 
 - (void)mapViewDidStartTileRendering:(GMSMapView *)mapView {
@@ -608,12 +608,12 @@ RCT_EXPORT_METHOD(setIndoorActiveLevelIndex:(nonnull NSNumber *)reactTag
 
 - (void)mapView:(GMSMapView *)mapView didChangeCameraPosition:(GMSCameraPosition *)position {
   AIRGoogleMap *googleMapView = (AIRGoogleMap *)mapView;
-  [googleMapView didChangeCameraPosition:position reason:self.reason];
+  [googleMapView didChangeCameraPosition:position isGesture:self.isGesture];
 }
 
 - (void)mapView:(GMSMapView *)mapView idleAtCameraPosition:(GMSCameraPosition *)position {
   AIRGoogleMap *googleMapView = (AIRGoogleMap *)mapView;
-  [googleMapView idleAtCameraPosition:position reason:self.reason];
+  [googleMapView idleAtCameraPosition:position isGesture:self.isGesture];
 }
 
 - (UIView *)mapView:(GMSMapView *)mapView markerInfoWindow:(GMSMarker *)marker {


### PR DESCRIPTION
### Does any other open PR do the same thing?

There is a PR that solves likely the problem #2935, but with a workaround.
The problem we are trying to solve is to know the reason when the region has changed on the map.
Using `onPanDrag`, implemented by the PR #2935, is a non stable workaround. Because will would have to first store somewhere a boolean on the `onPanDrag`, and use it once `onRegionChangeComplete`.

### What issue is this PR fixing?

Issue #1620 and #2756.

### How did you test this PR?

I implemented and tested (on a real device) the code for android. The iOS part too has been implemented by my friend. And was tested on an emulator.