### PR TITLE
Prefix call w/ self->

### DIFF
--- a/lib/ios/AirGoogleMaps/AIRGoogleMapMarker.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapMarker.m
@@ -340,7 +340,7 @@ CGRect unionRect(CGRect a, CGRect b) {
                                    NSLog(@"%@", error);
                                  }
                                  dispatch_async(dispatch_get_main_queue(), ^{
-                                   _realMarker.icon = image;
+                                   self->_realMarker.icon = image;
                                  });
                                }];
 }


### PR DESCRIPTION


### Does any other open PR do the same thing?


No.

### What issue is this PR fixing?

Fixes warning:

```
Block implicitly retains 'self'; explicitly mention 'self' to indicate this is intended behavior
```

### How did you test this PR?

Manually Tested.