### PR TITLE
fix animateCamera documentation

### DIFF
--- a/docs/mapview.md
+++ b/docs/mapview.md
@@ -81,7 +81,7 @@ To access event data, you will need to use `e.nativeEvent`. For example, `onPres
 | Method Name | Arguments | Notes
 |---|---|---|
 | `getCamera` | | Returns a `Camera` structure indicating the current camera configuration.
-| `animateCamera` | `camera: Camera`, `{ duration: Number }` | Animate the camera to a new view. You can pass a partial camera object here; any property not given will remain unmodified.
+| `animateCamera` | `camera: Camera`, `duration: Number` | Animate the camera to a new view. You can pass a partial camera object here; any property not given will remain unmodified.
 | `setCamera` | `camera: Camera`, `{ duration: Number }` | Like `animateCamera`, but sets the new view instantly, without an animation.
 | `animateToRegion` | `region: Region`, `duration: Number` |
 | `animateToNavigation` | `location: LatLng`, `bearing: Number`, `angle: Number`, `duration: Number` | Deprecated. Use `animateCamera` instead.


### PR DESCRIPTION
the documentation shows duration as an object but it's actually just number

<!--
PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.

**What happens if you SKIP this step?**

Your pull request will NOT be evaluated!

PLEASE NOTE THAT PRs WITHOUT THE TEMPLATE IN PLACE WILL BE CLOSED RIGHT FROM THE START.

Thanks for helping us help you!
-->

### Does any other open PR do the same thing?
No
<!--
**Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**

If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)
 -->

(please answer here)

### What issue is this PR fixing?
Documentation
(please link the issue here)

### How did you test this PR?
It's just documentation I tested that was correct
<!--
Please let us know how you have verified that your changes work.

Ideally, your PR should contain a step-by-step test plan, so that reviewers can easily verify your changes.

Your PR will have much better chances of being merged if it is straightforward to verify.

Some questions you might want to think about:

- Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any?
- Did you test this on a real device, or in a simulator?
- Are there any platforms you were not able to test?
-->
no
(please answer here)

<!--
Thanks for your contribution :)
-->
