### PR TITLE
Specify needed bundler version in example instructions

### DIFF
--- a/docs/examples-setup.md
+++ b/docs/examples-setup.md
@@ -2,10 +2,10 @@
 
 ## iOS
 
-1. If you don't have bundler gem installed:
+1. If you don't have the bundler gem at version 1.17.2 installed (another version won't work):
 
 ```
-gem install bundler
+gem install bundler:1.17.2
 ```
 
 2. Install dependencies and open the workspace:


### PR DESCRIPTION
### Does any other open PR do the same thing?
Nope! 
### What issue is this PR fixing?
This is just improving the documentation to build the example app for iOS. I needed to install `bundler:1.17.2` instead of just the latest version, so I thought it would be good to add that.

### How did you test this PR?

No testing necessary
