### PR TITLE
animateMarkerToCoordinate of undefined

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,7 +486,7 @@ componentWillReceiveProps(nextProps) {
   if (this.props.coordinate !== nextProps.coordinate) {
     if (Platform.OS === 'android') {
       if (this.marker) {
-        this.marker._component.animateMarkerToCoordinate(
+        this.marker.animateMarkerToCoordinate(
           nextProps.coordinate,
           duration
         );
@@ -523,7 +523,7 @@ componentWillReceiveProps(nextProps) {
   if (this.props.coordinate !== nextProps.coordinate) {
     if (Platform.OS === 'android') {
       if (this.marker) {
-        this.marker._component.animateMarkerToCoordinate(
+        this.marker.animateMarkerToCoordinate(
           nextProps.coordinate,
           duration
         );


### PR DESCRIPTION
I checked with 0.63.+ it was not working,, after removing `_component` before  animateMarkerToCoordinate working for Android. For more info have a look https://stackoverflow.com/a/63897282/3026578

### Does any other open PR do the same thing?

NO

### What issue is this PR fixing?

[Cannot read property 'animateMarkerToCoordinate' of undefined](https://stackoverflow.com/questions/61740171/cannot-read-property-animatemarkertocoordinate-of-undefined/)

### How did you test this PR?

after updating my project to latest react native version animateMarkerToCoordinate for Android stop working before it is working fine with recat-native version 0.61.+ . After removing _component before animateMarkerToCoordinate it is working fine now
