### PR TITLE
TypeScript Fix: Renamed invalid export type MapViewAnimated to Animated

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -298,7 +298,7 @@ declare module "react-native-maps" {
     setIndoorActiveLevelIndex(index:number): void;
   }
 
-  export class MapViewAnimated extends MapView {}
+  export class Animated extends MapView {}
 
   // =======================================================================
   //  Marker


### PR DESCRIPTION
### Does any other open PR do the same thing?

No

### What issue is this PR fixing?

It allow typescript to import the `Animated` export. Without it - anyone using typescript won't be able to import the `Animated` export.

### How did you test this PR?

As this change is only applied on the typescript definition - no test is necessary on the functionality of this plugin. 
But you can test the typescript support by simply importing the `Animated` export and transpile using TSC command. Which will allow the typescript import without any issue. 

Tested on latest stable Typescript 4.0.3. Also tested the code working by running the app on a Android device on debug mode.
