### PR TITLE
Added zIndex prop on Geojson

### DIFF
--- a/docs/geojson.md
+++ b/docs/geojson.md
@@ -13,6 +13,7 @@
 | `lineCap` |  `'butt' | 'round' | 'square'`     |  |  The line cap style to apply to the open ends of the path. Possible values are `butt`, `round` or `square`.  Note: lineCap is not yet supported for GoogleMaps provider on iOS. |
 | `lineJoin` | `'miter'| 'round' | 'bevel'`     |  |  The line join style to apply to corners of the path. Possible values are `miter`, `round` or `bevel`. |
 | `miterLimit` | `Number`     |  | The limiting value that helps avoid spikes at junctions between connected line segments. The miter limit helps you avoid spikes in paths that use the `miter` `lineJoin` style. If the ratio of the miter length—that is, the diagonal length of the miter join—to the line thickness exceeds the miter limit, the joint is converted to a bevel join. The default miter limit is 10, which results in the conversion of miters whose angle at the joint is less than 11 degrees. | 
+| `zIndex` | `Number`     |  | Layer level of the z-index value |
 
 ## Example
 

--- a/lib/components/Geojson.js
+++ b/lib/components/Geojson.js
@@ -107,6 +107,7 @@ const Geojson = props => {
               coordinate={overlay.coordinates}
               image={props.image}
               pinColor={props.color}
+              zIndex={props.zIndex}
             />
           );
         }
@@ -121,6 +122,7 @@ const Geojson = props => {
               strokeWidth={props.strokeWidth}
               tappable={props.tappable}
               onPress={props.onPress}
+              zIndex={props.zIndex}
             />
           );
         }
@@ -136,11 +138,12 @@ const Geojson = props => {
               lineCap={props.lineCap}
               lineJoin={props.lineJoin}
               miterLimit={props.miterLimit}
+              zIndex={props.zIndex}
             />
           );
         }
       })}
-    </React.Fragment>
+  </React.Fragment>
   );
 };
 

--- a/lib/components/Geojson.js
+++ b/lib/components/Geojson.js
@@ -143,7 +143,7 @@ const Geojson = props => {
           );
         }
       })}
-  </React.Fragment>
+    </React.Fragment>
   );
 };
 


### PR DESCRIPTION
### Does any other open PR do the same thing?

No, there is no another PR to add this functionality.

### What issue is this PR fixing?

#3491 

### How did you test this PR?

- Tested on both Android and iOS Platforms with Google API key.
- I've tested this on both in real device and a simulator.


This simply adds the `zIndex` prop for the `Geojson` component. It lets developers to use multiple Geojson into each other.

