### PR TITLE
fix crash of double tap

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -1122,6 +1122,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
   }
 
   public void onDoublePress(MotionEvent ev) {
+    if (this.map == null) return;
     Point point = new Point((int) ev.getX(), (int) ev.getY());
     LatLng coords = this.map.getProjection().fromScreenLocation(point);
     WritableMap event = makeClickEventData(coords);


### PR DESCRIPTION
fix crash when double tap on a not initialized map view


### Does any other open PR do the same thing?

No.

### What issue is this PR fixing?

#3653 

### How did you test this PR?

return if map is null in doubeTap's handler 


