### PR TITLE
Geojson stroke color, stroke width, fill color, and marker color properties preserved

### DIFF
--- a/docs/geojson.md
+++ b/docs/geojson.md
@@ -5,9 +5,9 @@
 | Prop      | Type | Default                                                | Note |
 | --------- | ---- | ------------------------------------------------------ | ---- |
 | `geojson` |  `GeoJSON`    |  | [Geojson](https://geojson.org/) description of object. |
-| `strokeColor` | `String`     | `#000` | The stroke color to use for the path.  |
-| `fillColor` | `String`     |  | The fill color to use for the path. |
-| `strokeWidth` | `Number`     | `1` | The stroke width to use for the path. |
+| `strokeColor` | `String`     | stroke color in GeoJson if present else `#000` | The stroke color to use for the path.  |
+| `fillColor` | `String`     | fill color in GeoJson | The fill color to use for the path. |
+| `strokeWidth` | `Number`     | stroke width in Geojson if present else `1` | The stroke width to use for the path. |
 | `lineDashPhase` | `Number`     |  |  (iOS only) The offset (in points) at which to start drawing the dash pattern. Use this property to start drawing a dashed line partway through a segment or gap. For example, a phase value of 6 for the patter 5-2-3-2 would cause drawing to begin in the middle of the first gap. |
 | `lineDashPattern` | `Array<Number>`     |  | An array of numbers specifying the dash pattern to use for the path. The array contains one or more numbers that indicate the lengths (measured in points) of the  line segments and gaps in the pattern. The values in the array alternate, starting with the first line segment length, followed by the first gap length, followed by the second line segment length, and so on. |
 | `lineCap` |  `'butt' | 'round' | 'square'`     |  |  The line cap style to apply to the open ends of the path. Possible values are `butt`, `round` or `square`.  Note: lineCap is not yet supported for GoogleMaps provider on iOS. |

--- a/lib/components/Geojson.js
+++ b/lib/components/Geojson.js
@@ -95,18 +95,69 @@ const makeCoordinates = feature => {
   }
 };
 
+const doesOverlayContainProperty = (overlay, property) => {
+  // Geojson may have 0 for the opacity when intention is to not specify the
+  // opacity. Therefore, we evaluate the truthiness of the propery where 0
+  // would return false.
+  return (
+    overlay.feature &&
+    overlay.feature.properties &&
+    overlay.feature.properties[property]
+  );
+};
+
+const getRgbaFromHex = (hex, alpha = 1) => {
+  const [r, g, b] = hex.match(/\w\w/g).map(x => parseInt(x, 16));
+  return `rgba(${r},${g},${b},${alpha})`;
+};
+
+const getColor = (props, overlay, colorType, overrideColorProp) => {
+  if (props.hasOwnProperty(overrideColorProp)) {
+    return props[overrideColorProp];
+  }
+  if (doesOverlayContainProperty(overlay, colorType)) {
+    let color = overlay.feature.properties[colorType];
+    const opacityProperty = colorType + '-opacity';
+    if (
+      doesOverlayContainProperty(overlay, opacityProperty) &&
+      color[0] === '#'
+    ) {
+      color = getRgbaFromHex(
+        color,
+        overlay.feature.properties[opacityProperty]
+      );
+    }
+    return color;
+  }
+  return null;
+};
+
+const getStrokeWidth = (props, overlay) => {
+  if (props.hasOwnProperty('strokeWidth')) {
+    return props['strokeWidth'];
+  }
+  if (doesOverlayContainProperty(overlay, 'stroke-width')) {
+    return overlay.feature.properties['stroke-width'];
+  }
+  return null;
+};
+
 const Geojson = props => {
   const overlays = makeOverlays(props.geojson.features);
   return (
     <React.Fragment>
       {overlays.map((overlay, index) => {
+        const fillColor = getColor(props, overlay, 'fill', 'fillColor');
+        const strokeColor = getColor(props, overlay, 'stroke', 'strokeColor');
+        const markerColor = getColor(props, overlay, 'marker-color', 'color');
+        const strokeWidth = getStrokeWidth(props, overlay);
         if (overlay.type === 'point') {
           return (
             <Marker
               key={index}
               coordinate={overlay.coordinates}
               image={props.image}
-              pinColor={props.color}
+              pinColor={markerColor}
               zIndex={props.zIndex}
             />
           );
@@ -117,9 +168,9 @@ const Geojson = props => {
               key={index}
               coordinates={overlay.coordinates}
               holes={overlay.holes}
-              strokeColor={props.strokeColor}
-              fillColor={props.fillColor}
-              strokeWidth={props.strokeWidth}
+              strokeColor={strokeColor}
+              fillColor={fillColor}
+              strokeWidth={strokeWidth}
               tappable={props.tappable}
               onPress={props.onPress}
               zIndex={props.zIndex}
@@ -131,8 +182,8 @@ const Geojson = props => {
             <Polyline
               key={index}
               coordinates={overlay.coordinates}
-              strokeColor={props.strokeColor}
-              strokeWidth={props.strokeWidth}
+              strokeColor={strokeColor}
+              strokeWidth={strokeWidth}
               lineDashPhase={props.lineDashPhase}
               lineDashPattern={props.lineDashPattern}
               lineCap={props.lineCap}


### PR DESCRIPTION

### Does any other open PR do the same thing?

<!--
**Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**

If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)
 -->

No

### What issue is this PR fixing?

The GeoJson feature of this library does not preserve the stroke width, stroke color, fill color, and marker color properties from the GeoJson supplied. This PR now preserves all those properties and successfully displays map elements with those styling properties. 

While these two issues may not be specifically about GeoJson, much of comments are about the GeoJson styling issue:
#2867 #3057

### How did you test this PR?

<!--
Please let us know how you have verified that your changes work.

Ideally, your PR should contain a step-by-step test plan, so that reviewers can easily verify your changes.

Your PR will have much better chances of being merged if it is straightforward to verify.

Some questions you might want to think about:

- Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any?
- Did you test this on a real device, or in a simulator?
- Are there any platforms you were not able to test?
-->

This PR was tested with Android and iOS simulators, although the same logic was tested in a patch on real iOS and Android devices. 

Using a GeoJson creator like [https://geojson.io/](https://geojson.io/) - it is easy to create map elements with properties in the GeoJson. From there, it's just a matter of firing up an app that uses the GeoJson you created in a map view.

<!--
Thanks for your contribution :)
-->
