### PR TITLE
Add edgePadding support to fitToElements method.

### DIFF
--- a/docs/mapview.md
+++ b/docs/mapview.md
@@ -92,7 +92,7 @@ To access event data, you will need to use `e.nativeEvent`. For example, `onPres
 | `getMapBoundaries` | | `Promise<{northEast: LatLng, southWest: LatLng}>`
 | `setMapBoundaries` | `northEast: LatLng`, `southWest: LatLng` | The boundary is defined by the map's center coordinates, not the device's viewport itself. **Note:** Google Maps only.
 | `setIndoorActiveLevelIndex` | `levelIndex: Number` |
-| `fitToElements` | `animated: Boolean` |
+| `fitToElements` | `options: { edgePadding: EdgePadding, animated: Boolean }` | **Note** edgePadding is Google Maps only
 | `fitToSuppliedMarkers` | `markerIDs: String[], options: { edgePadding: EdgePadding, animated: Boolean }` | If you need to use this in `ComponentDidMount`, make sure you put it in a timeout or it will cause performance problems. **Note** edgePadding is Google Maps only
 | `fitToCoordinates` | `coordinates: Array<LatLng>, options: { edgePadding: EdgePadding, animated: Boolean }` | If called in `ComponentDidMount` in android, it will cause an exception. It is recommended to call it from the MapView `onLayout` event.
 | `pointForCoordinate` | `coordinate: LatLng` | Converts a map coordinate to a view coordinate (`Point`). Returns a `Promise<Point>`.

--- a/example/examples/MapKml.js
+++ b/example/examples/MapKml.js
@@ -28,7 +28,7 @@ class MapKml extends React.Component {
   }
 
   onKmlReady() {
-    this.map.fitToElements(true);
+    this.map.fitToElements({ animated: true });
   }
 
   render() {

--- a/index.d.ts
+++ b/index.d.ts
@@ -281,7 +281,7 @@ declare module "react-native-maps" {
     animateToCoordinate(latLng: LatLng, duration?: number): void;
     animateToBearing(bearing: number, duration?: number): void;
     animateToViewingAngle(angle: number, duration?: number): void;
-    fitToElements(animated: boolean): void;
+    fitToElements(options?: { edgePadding?: EdgePadding, animated?: boolean }): void;
     fitToSuppliedMarkers(
       markers: string[],
       options?: { edgePadding?: EdgePadding; animated?: boolean }

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
@@ -354,7 +354,7 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
         break;
 
       case FIT_TO_ELEMENTS:
-        view.fitToElements(args.getBoolean(0));
+        view.fitToElements(args.getMap(0), args.getBoolean(1));
         break;
 
       case FIT_TO_SUPPLIED_MARKERS:

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -827,7 +827,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     map.animateCamera(CameraUpdateFactory.newLatLng(coordinate), duration, null);
   }
 
-  public void fitToElements(boolean animated) {
+  public void fitToElements(ReadableMap edgePadding, boolean animated) {
     if (map == null) return;
 
     LatLngBounds.Builder builder = new LatLngBounds.Builder();
@@ -845,6 +845,12 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     if (addedPosition) {
       LatLngBounds bounds = builder.build();
       CameraUpdate cu = CameraUpdateFactory.newLatLngBounds(bounds, baseMapPadding);
+
+      if (edgePadding != null) {
+        map.setPadding(edgePadding.getInt("left"), edgePadding.getInt("top"),
+          edgePadding.getInt("right"), edgePadding.getInt("bottom"));
+      }
+
       if (animated) {
         map.animateCamera(cu);
       } else {

--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -706,8 +706,13 @@ class MapView extends React.Component {
     this._runCommand('animateToViewingAngle', [angle, duration || 500]);
   }
 
-  fitToElements(animated) {
-    this._runCommand('fitToElements', [animated]);
+  fitToElements(options = {}) {
+    const {
+      edgePadding = { top: 0, right: 0, bottom: 0, left: 0 },
+      animated = true,
+    } = options;
+
+    this._runCommand('fitToElements', [edgePadding, animated]);
   }
 
   fitToSuppliedMarkers(markers, options = {}) {

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
@@ -262,6 +262,7 @@ RCT_EXPORT_METHOD(animateToBearing:(nonnull NSNumber *)reactTag
 }
 
 RCT_EXPORT_METHOD(fitToElements:(nonnull NSNumber *)reactTag
+                  edgePadding:(nonnull NSDictionary *)edgePadding
                   animated:(BOOL)animated)
 {
   [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
@@ -276,9 +277,20 @@ RCT_EXPORT_METHOD(fitToElements:(nonnull NSNumber *)reactTag
 
       for (AIRGoogleMapMarker *marker in mapView.markers)
         bounds = [bounds includingCoordinate:marker.realMarker.position];
-
-      GMSCameraUpdate *cameraUpdate = [GMSCameraUpdate fitBounds:bounds withPadding:55.0f];
-
+        
+        GMSCameraUpdate* cameraUpdate;
+        
+        if ([edgePadding count] != 0) {
+            // Set Map viewport
+            CGFloat top = [RCTConvert CGFloat:edgePadding[@"top"]];
+            CGFloat right = [RCTConvert CGFloat:edgePadding[@"right"]];
+            CGFloat bottom = [RCTConvert CGFloat:edgePadding[@"bottom"]];
+            CGFloat left = [RCTConvert CGFloat:edgePadding[@"left"]];
+            
+            cameraUpdate = [GMSCameraUpdate fitBounds:bounds withEdgeInsets:UIEdgeInsetsMake(top, left, bottom, right)];
+        } else {
+            cameraUpdate = [GMSCameraUpdate fitBounds:bounds withPadding:55.0f];
+        }
       if (animated) {
         [mapView animateWithCameraUpdate: cameraUpdate];
       } else {
@@ -682,7 +694,7 @@ RCT_EXPORT_METHOD(setIndoorActiveLevelIndex:(nonnull NSNumber *)reactTag
   );
 }
 
-- (void) didChangeActiveLevel: (nullable GMSIndoorLevel *) 	level {
+- (void) didChangeActiveLevel: (nullable GMSIndoorLevel *) level {
   if (!self.map.onIndoorLevelActivated || !self.map.indoorDisplay  || !level) {
     return;
   }

--- a/lib/ios/AirMaps/AIRMapManager.m
+++ b/lib/ios/AirMaps/AIRMapManager.m
@@ -380,6 +380,7 @@ RCT_EXPORT_METHOD(animateToBearing:(nonnull NSNumber *)reactTag
 }
 
 RCT_EXPORT_METHOD(fitToElements:(nonnull NSNumber *)reactTag
+        edgePadding:(nonnull NSDictionary *)edgePadding
         animated:(BOOL)animated)
 {
     [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {


### PR DESCRIPTION
### Does any other open PR do the same thing?

There is no previous PR which does the same thing. 

### What issue is this PR fixing?

The method fitToElements does not support edge padding. 
It should have the same api as fitToSuppliedMarkers and fitToCoordinates.

### How did you test this PR?

We have tested the changes on iOS and Android using physical devices on both platforms. 

These changes only affect Google Maps and not Apple Maps, as I've also clarified in the readme. 

You can test the new functionality by passing edgePadding to the fitToElements function and see how the markers are no longer aligned with the very edge of the map. Instead it uses the provided padding. 
