### PR TITLE
Clarify in the documentation that the edgePadding option for fitToSup…

### DIFF
--- a/docs/mapview.md
+++ b/docs/mapview.md
@@ -93,7 +93,7 @@ To access event data, you will need to use `e.nativeEvent`. For example, `onPres
 | `setMapBoundaries` | `northEast: LatLng`, `southWest: LatLng` | The boundary is defined by the map's center coordinates, not the device's viewport itself. **Note:** Google Maps only.
 | `setIndoorActiveLevelIndex` | `levelIndex: Number` |
 | `fitToElements` | `animated: Boolean` |
-| `fitToSuppliedMarkers` | `markerIDs: String[], options: { edgePadding: EdgePadding, animated: Boolean }` | If you need to use this in `ComponentDidMount`, make sure you put it in a timeout or it will cause performance problems.
+| `fitToSuppliedMarkers` | `markerIDs: String[], options: { edgePadding: EdgePadding, animated: Boolean }` | If you need to use this in `ComponentDidMount`, make sure you put it in a timeout or it will cause performance problems. **Note** edgePadding is Google Maps only
 | `fitToCoordinates` | `coordinates: Array<LatLng>, options: { edgePadding: EdgePadding, animated: Boolean }` | If called in `ComponentDidMount` in android, it will cause an exception. It is recommended to call it from the MapView `onLayout` event.
 | `pointForCoordinate` | `coordinate: LatLng` | Converts a map coordinate to a view coordinate (`Point`). Returns a `Promise<Point>`.
 | `coordinateForPoint` | `point: Point` | Converts a view coordinate (`Point`) to a map coordinate. Returns a `Promise<Coordinate>`.


### PR DESCRIPTION
Clarify in the documentation that the edgePadding option for fitToSuppliedMarkers is only supported for Google Maps



### Does any other open PR do the same thing?

No other PR does the same thing. 

### What issue is this PR fixing?

fitToSuppliedMarkers disregards edgePadding when using Apple MapKit. This is now clarified in the documentation. 

### How did you test this PR?

I've tested on iOS that what I've stated is true. Is disregards edgePadding. 
