### PR TITLE
Android - Use double on `setCamera` to fix zoom precision. 

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -508,7 +508,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
 
     builder.tilt((float)camera.getDouble("pitch"));
     builder.bearing((float)camera.getDouble("heading"));
-    builder.zoom(camera.getFloat("zoom"));
+    builder.zoom((float)camera.getDouble("zoom"));
 
     CameraUpdate update = CameraUpdateFactory.newCameraPosition(builder.build());
 

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -508,7 +508,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
 
     builder.tilt((float)camera.getDouble("pitch"));
     builder.bearing((float)camera.getDouble("heading"));
-    builder.zoom(camera.getDouble("zoom"));
+    builder.zoom(camera.getFloat("zoom"));
 
     CameraUpdate update = CameraUpdateFactory.newCameraPosition(builder.build());
 

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -508,7 +508,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
 
     builder.tilt((float)camera.getDouble("pitch"));
     builder.bearing((float)camera.getDouble("heading"));
-    builder.zoom(camera.getInt("zoom"));
+    builder.zoom(camera.getDouble("zoom"));
 
     CameraUpdate update = CameraUpdateFactory.newCameraPosition(builder.build());
 


### PR DESCRIPTION
### Does any other open PR do the same thing?
No, no other PRs deal with Camera Zoom. 

### What issue is this PR fixing?
It is fixing issue #3725 on Android devices. It is pretty simple. 

### How did you test this PR?
* I tested this PR in my own little project. The fix is so minimal that I didn't really see it necessary to create an online sample. If you'd like me to make a sample code, I'd happily do it.
* It's tested on a Google Pixel 4a phone. 
* I haven't tried iOS, this wouldn't affect iOS anyways. 