### PR TITLE
Android:Fix fitToCoordinates with preset mapPadding (#3308)

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
@@ -152,6 +152,7 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
       }
     }
 
+    view.applyBaseMapPadding(left, top, right, bottom);
     view.map.setPadding(left, top, right, bottom);
   }
 

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -1315,4 +1315,19 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
 
     return airMarker;
   }
+
+  @Override
+  public void requestLayout() {
+    super.requestLayout();
+    post(measureAndLayout);
+  }
+
+  private final Runnable measureAndLayout = new Runnable() {
+    @Override
+    public void run() {
+      measure(MeasureSpec.makeMeasureSpec(getWidth(), MeasureSpec.EXACTLY),
+              MeasureSpec.makeMeasureSpec(getHeight(), MeasureSpec.EXACTLY));
+      layout(getLeft(), getTop(), getRight(), getBottom());
+    }
+  };
 }

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -895,6 +895,19 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     }
   }
 
+  int baseLeftMapPadding;
+  int baseRightMapPadding;
+  int baseTopMapPadding;
+  int baseBottomMapPadding;
+
+  public void applyBaseMapPadding(int left, int top, int right, int bottom){
+    this.map.setPadding(left, top, right, bottom);
+    baseLeftMapPadding = left;
+    baseRightMapPadding = right;
+    baseTopMapPadding = top;
+    baseBottomMapPadding = bottom;
+  }
+
   public void fitToCoordinates(ReadableArray coordinatesArray, ReadableMap edgePadding,
       boolean animated) {
     if (map == null) return;
@@ -912,8 +925,10 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     CameraUpdate cu = CameraUpdateFactory.newLatLngBounds(bounds, baseMapPadding);
 
     if (edgePadding != null) {
-      map.setPadding(edgePadding.getInt("left"), edgePadding.getInt("top"),
-          edgePadding.getInt("right"), edgePadding.getInt("bottom"));
+      map.setPadding(edgePadding.getInt("left") + baseLeftMapPadding,
+              edgePadding.getInt("top") + baseTopMapPadding,
+              edgePadding.getInt("right") + baseRightMapPadding,
+              edgePadding.getInt("bottom") + baseBottomMapPadding);
     }
 
     if (animated) {
@@ -921,8 +936,8 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     } else {
       map.moveCamera(cu);
     }
-    map.setPadding(0, 0, 0,
-        0); // Without this, the Google logo is moved up by the value of edgePadding.bottom
+    // Move the google logo to the default base padding value.
+    map.setPadding(baseLeftMapPadding, baseTopMapPadding, baseRightMapPadding, baseBottomMapPadding);
   }
 
   public double[][] getMapBoundaries() {


### PR DESCRIPTION
<!--
PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.

**What happens if you SKIP this step?**

Your pull request will NOT be evaluated!

PLEASE NOTE THAT PRs WITHOUT THE TEMPLATE IN PLACE WILL BE CLOSED RIGHT FROM THE START.

Thanks for helping us help you!
-->

### Does any other open PR do the same thing?

<!--
**Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**

If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)
 -->

NO

### What issue is this PR fixing?

#3308 

### How did you test this PR?

<!--
Please let us know how you have verified that your changes work.

Ideally, your PR should contain a step-by-step test plan, so that reviewers can easily verify your changes.

Your PR will have much better chances of being merged if it is straightforward to verify.

Some questions you might want to think about:

- Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any?
- Did you test this on a real device, or in a simulator?
- Are there any platforms you were not able to test?
-->

Just verify it by following steps : 

1. Set mapPadding to the `MapView` in `example/examples/FitToCoordinates.js:69`, such as 
```
<MapView
...
mapPadding={{ left: 15, top: 0, right: 0, bottom: 60 }}
...
>
```
2. Run the demo app from this PR on Android
3. Enter `Fit Map To Coordinates`, you can see the Google watermark is located with padding.
4. Click Btn `Fit Bottom Two Markers with Padding`
5. Camera zooms in those two Markers while Google watermark keeps in the same position instead of moving to the initial pos.
6. Problem solved
<!--
Thanks for your contribution :)
-->
