### PR TITLE
Fix fitToCoordinates edgePadding unit (#3308)

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -925,10 +925,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     CameraUpdate cu = CameraUpdateFactory.newLatLngBounds(bounds, baseMapPadding);
 
     if (edgePadding != null) {
-      map.setPadding(edgePadding.getInt("left") + baseLeftMapPadding,
-              edgePadding.getInt("top") + baseTopMapPadding,
-              edgePadding.getInt("right") + baseRightMapPadding,
-              edgePadding.getInt("bottom") + baseBottomMapPadding);
+      appendMapPadding(edgePadding.getInt("left"), edgePadding.getInt("top"), edgePadding.getInt("right"), edgePadding.getInt("bottom"));
     }
 
     if (animated) {
@@ -938,6 +935,24 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     }
     // Move the google logo to the default base padding value.
     map.setPadding(baseLeftMapPadding, baseTopMapPadding, baseRightMapPadding, baseBottomMapPadding);
+  }
+
+  private void appendMapPadding(int iLeft,int iTop, int iRight, int iBottom) {
+    int left;
+    int top;
+    int right;
+    int bottom;
+    double density = getResources().getDisplayMetrics().density;
+
+    left = (int) (iLeft * density);
+    top = (int) (iTop * density);
+    right = (int) (iRight * density);
+    bottom = (int) (iBottom * density);
+
+    map.setPadding(left + baseLeftMapPadding,
+            top + baseTopMapPadding,
+            right + baseRightMapPadding,
+            bottom + baseBottomMapPadding);
   }
 
   public double[][] getMapBoundaries() {


### PR DESCRIPTION
<!--
PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.

**What happens if you SKIP this step?**

Your pull request will NOT be evaluated!

PLEASE NOTE THAT PRs WITHOUT THE TEMPLATE IN PLACE WILL BE CLOSED RIGHT FROM THE START.

Thanks for helping us help you!
-->

### Does any other open PR do the same thing?

<!--
**Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**

If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)
 -->

No

### What issue is this PR fixing?

#3308 relevant

The adding edgePadding in fitToCoordinates method hasn't been considered the unit before.

Need to change apply the density which is changing from DP to px.

When setting `edgePaddingTop=200` in a `MapView` which has `mapPaddingTop` 200 already.
Before 
<img src="https://user-images.githubusercontent.com/6284688/110773636-e9da4300-8297-11eb-80a1-9deaff79ee4b.jpg" width=30% height=30%/>

After 
<img src="https://user-images.githubusercontent.com/6284688/110773642-ecd53380-8297-11eb-9296-b8a2f6d25da0.jpg" width=30% height=30%/>


### How did you test this PR?

<!--
Please let us know how you have verified that your changes work.

Ideally, your PR should contain a step-by-step test plan, so that reviewers can easily verify your changes.

Your PR will have much better chances of being merged if it is straightforward to verify.

Some questions you might want to think about:

- Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any?
- Did you test this on a real device, or in a simulator?
- Are there any platforms you were not able to test?
-->

To verify this change, apply edgePadding and mapPadding as follow. 
```
this.map.fitToCoordinates([MARKERS[2], MARKERS[3]], {
      edgePadding: { top: 200, right: 0, bottom: 0, left: 0 },
      animated: true,
    });
```

```
 <MapView
          ref={ref => {
            this.map = ref;
          }}
          style={styles.map}
          initialRegion={{
            latitude: LATITUDE,
            longitude: LONGITUDE,
            latitudeDelta: LATITUDE_DELTA,
            longitudeDelta: LONGITUDE_DELTA,
          }}
          mapPadding={{ left: 0, top: 200, right: 0, bottom: 60 }}
>
```

<!--
Thanks for your contribution :)
-->
