### PR TITLE
Fix indoor events on iOS for multiple MapViews

### DIFF
--- a/lib/ios/AirGoogleMaps/AIRGoogleMap.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMap.m
@@ -49,7 +49,7 @@ id regionAsJSON(MKCoordinateRegion region) {
            };
 }
 
-@interface AIRGoogleMap ()
+@interface AIRGoogleMap () <GMSIndoorDisplayDelegate>
 
 - (id)eventFromCoordinate:(CLLocationCoordinate2D)coordinate;
 
@@ -95,6 +95,8 @@ id regionAsJSON(MKCoordinateRegion region) {
               context:NULL];
 
     self.origGestureRecognizersMeta = [[NSMutableDictionary alloc] init];
+
+    self.indoorDisplay.delegate = self;
   }
   return self;
 }
@@ -879,6 +881,63 @@ id regionAsJSON(MKCoordinateRegion region) {
     REQUIRES_GOOGLE_MAPS_UTILS();
 #endif
 }
+
+
+- (void) didChangeActiveBuilding: (nullable GMSIndoorBuilding *) building {
+    if (!building) {
+        if (!self.onIndoorBuildingFocused) {
+            return;
+        }
+        self.onIndoorBuildingFocused(@{
+            @"IndoorBuilding": @{
+                    @"activeLevelIndex": @0,
+                    @"underground": @false,
+                    @"levels": [[NSMutableArray alloc]init]
+            }
+        });
+    }
+    NSInteger i = 0;
+    NSMutableArray *arrayLevels = [[NSMutableArray alloc]init];
+    for (GMSIndoorLevel *level in building.levels) {
+        [arrayLevels addObject: @{
+            @"index": @(i),
+            @"name" : level.name,
+            @"shortName" : level.shortName,
+        }];
+        i++;
+    }
+    if (!self.onIndoorBuildingFocused) {
+        return;
+    }
+    self.onIndoorBuildingFocused(@{
+        @"IndoorBuilding": @{
+                @"activeLevelIndex": @(building.defaultLevelIndex),
+                @"underground": @(building.underground),
+                @"levels": arrayLevels
+        }
+    });
+}
+
+- (void) didChangeActiveLevel: (nullable GMSIndoorLevel *)     level {
+    if (!self.onIndoorLevelActivated || !self.indoorDisplay  || !level) {
+        return;
+    }
+    NSInteger i = 0;
+    for (GMSIndoorLevel *buildingLevel in self.indoorDisplay.activeBuilding.levels) {
+        if (buildingLevel.name == level.name && buildingLevel.shortName == level.shortName) {
+            break;
+        }
+        i++;
+    }
+    self.onIndoorLevelActivated(@{
+        @"IndoorLevel": @{
+                @"activeLevelIndex": @(i),
+                @"name": level.name,
+                @"shortName": level.shortName
+        }
+    });
+}
+
 
 @end
 

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapManager.h
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapManager.h
@@ -8,10 +8,8 @@
 #ifdef HAVE_GOOGLE_MAPS
 
 #import <React/RCTViewManager.h>
-#import "AIRGoogleMap.h"
 
 @interface AIRGoogleMapManager : RCTViewManager
-@property (nonatomic, assign) AIRGoogleMap *map;
 @property (nonatomic) BOOL isGesture;
 
 @end

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
@@ -33,7 +33,7 @@
 static NSString *const RCTMapViewKey = @"MapView";
 
 
-@interface AIRGoogleMapManager() <GMSMapViewDelegate, GMSIndoorDisplayDelegate>
+@interface AIRGoogleMapManager() <GMSMapViewDelegate>
 {
   BOOL didCallOnMapReady;
 }
@@ -51,8 +51,6 @@ RCT_EXPORT_MODULE()
   map.isAccessibilityElement = NO;
   map.accessibilityElementsHidden = NO;
   map.settings.consumesGesturesInView = NO;
-  map.indoorDisplay.delegate = self;
-  self.map = map;
 
   UIPanGestureRecognizer *drag = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(handleMapDrag:)];
   [drag setMinimumNumberOfTouches:1];
@@ -554,11 +552,11 @@ RCT_EXPORT_METHOD(setIndoorActiveLevelIndex:(nonnull NSNumber *)reactTag
       RCTLogError(@"Invalid view returned from registry, expecting AIRGoogleMap, got: %@", view);
     } else {
       AIRGoogleMap *mapView = (AIRGoogleMap *)view;
-      if (!self.map.indoorDisplay) {
+      if (!mapView.indoorDisplay) {
         return;
       }
-      if ( levelIndex < [self.map.indoorDisplay.activeBuilding.levels count]) {
-        mapView.indoorDisplay.activeLevel = self.map.indoorDisplay.activeBuilding.levels[levelIndex];
+      if ( levelIndex < [mapView.indoorDisplay.activeBuilding.levels count]) {
+        mapView.indoorDisplay.activeLevel = mapView.indoorDisplay.activeBuilding.levels[levelIndex];
       }
     }
   }];
@@ -643,63 +641,6 @@ RCT_EXPORT_METHOD(setIndoorActiveLevelIndex:(nonnull NSNumber *)reactTag
 - (void)mapView:(GMSMapView *)mapView didDragMarker:(GMSMarker *)marker {
   AIRGMSMarker *aMarker = (AIRGMSMarker *)marker;
   [aMarker.fakeMarker didDragMarker:aMarker];
-}
-
-- (void) didChangeActiveBuilding: (nullable GMSIndoorBuilding *) building {
-  if (!building) {
-    if (!self.map.onIndoorBuildingFocused) {
-      return;
-    }
-    self.map.onIndoorBuildingFocused(@{
-                                      @"IndoorBuilding": @{
-                                          @"activeLevelIndex": @0,
-                                          @"underground": @false,
-                                          @"levels": [[NSMutableArray alloc]init]
-                                      }
-    });
-  }
-  NSInteger i = 0;
-  NSMutableArray *arrayLevels = [[NSMutableArray alloc]init];
-  for (GMSIndoorLevel *level in building.levels) {
-    [arrayLevels addObject: @{
-                              @"index": @(i),
-                              @"name" : level.name,
-                              @"shortName" : level.shortName,
-                            }
-    ];
-    i++;
-  }
-  if (!self.map.onIndoorBuildingFocused) {
-    return;
-  }
-  self.map.onIndoorBuildingFocused(@{
-                                    @"IndoorBuilding": @{
-                                        @"activeLevelIndex": @(building.defaultLevelIndex),
-                                        @"underground": @(building.underground),
-                                        @"levels": arrayLevels
-                                    }
-                                  }
-  );
-}
-
-- (void) didChangeActiveLevel: (nullable GMSIndoorLevel *) 	level {
-  if (!self.map.onIndoorLevelActivated || !self.map.indoorDisplay  || !level) {
-    return;
-  }
-  NSInteger i = 0;
-  for (GMSIndoorLevel *buildingLevel in self.map.indoorDisplay.activeBuilding.levels) {
-    if (buildingLevel.name == level.name && buildingLevel.shortName == level.shortName) {
-      break;
-    }
-    i++;
-  }
-  self.map.onIndoorLevelActivated(@{
-                                  @"IndoorLevel": @{
-                                    @"activeLevelIndex": @(i),
-                                    @"name": level.name,
-                                    @"shortName": level.shortName
-                                  }
-  });
 }
 
 - (void)mapView:(GMSMapView *)mapView


### PR DESCRIPTION
<!--
PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.

**What happens if you SKIP this step?**

Your pull request will NOT be evaluated!

PLEASE NOTE THAT PRs WITHOUT THE TEMPLATE IN PLACE WILL BE CLOSED RIGHT FROM THE START.

Thanks for helping us help you!
-->

### Does any other open PR do the same thing?

<!--
**Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**

If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)
 -->

No

### What issue is this PR fixing?

See #3014
When there are multiple maps and one is removed the iOS app crashes on an indoor event.

### How did you test this PR?

<!--
Please let us know how you have verified that your changes work.

Ideally, your PR should contain a step-by-step test plan, so that reviewers can easily verify your changes.

Your PR will have much better chances of being merged if it is straightforward to verify.

Some questions you might want to think about:

- Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any?
- Did you test this on a real device, or in a simulator?
- Are there any platforms you were not able to test?
-->

Tested on a simulator. I rendered 2 MapViews and dynamically toggled the second while triggering and monitoring indoor events on both maps.

<!--
Thanks for your contribution :)
-->
