### PR TITLE
Update polygon.md

### DIFF
--- a/docs/polygon.md
+++ b/docs/polygon.md
@@ -16,6 +16,7 @@
 | `lineDashPhase` | `Number` | `0` | (iOS only) The offset (in points) at which to start drawing the dash pattern. Use this property to start drawing a dashed line partway through a segment or gap. For example, a phase value of 6 for the patter 5-2-3-2 would cause drawing to begin in the middle of the first gap.
 | `lineDashPattern` | `Array<Number>` | `null` | (iOS only) An array of numbers specifying the dash pattern to use for the path. The array contains one or more numbers that indicate the lengths (measured in points) of the  line segments and gaps in the pattern. The values in the array alternate, starting with the first line segment length, followed by the first gap length, followed by the second line segment length, and so on.
 | `tappable` | `Bool` | false | Boolean to allow a polygon to be tappable and use the onPress function.
+| `zIndex`   | `Number` | 0 | The order in which this polygon overlay is drawn with respect to other overlays. An overlay with a larger z-index is drawn over overlays with smaller z-indices. The order of overlays with the same z-index is arbitrary. The default zIndex is 0. (Android Only)
 
 ## Events
 


### PR DESCRIPTION
Documented the availability of zIndex prop in Polygon.  This is useful if you're drawing a polygon on top of custom tiles, for example; a zIndex of 1 ensures the Polygon is visible on top of the tiles.

<!--
PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.

**What happens if you SKIP this step?**

Your pull request will NOT be evaluated!

PLEASE NOTE THAT PRs WITHOUT THE TEMPLATE IN PLACE WILL BE CLOSED RIGHT FROM THE START.

Thanks for helping us help you!
-->

### Does any other open PR do the same thing?

<!--
**Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**

If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)
 -->

N/A - Another PR for this doesn't seem to exist.

### What issue is this PR fixing?

The Polygon documentation does not mention the existence of the zIndex prop.

### How did you test this PR?

I used the zIndex prop in code on Android and it worked.

<!--
Please let us know how you have verified that your changes work.

Ideally, your PR should contain a step-by-step test plan, so that reviewers can easily verify your changes.

Your PR will have much better chances of being merged if it is straightforward to verify.

Some questions you might want to think about:

- Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any?
- Did you test this on a real device, or in a simulator?
- Are there any platforms you were not able to test?
-->

Yes, I've verified that zIndex works, and that Polygon drawn over custom tiles without the zIndex prop can be obscured by rendering of the tiles.

<!--
Thanks for your contribution :)
-->
