### PR TITLE
Fix import/local conflict in typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 declare module 'react-native-maps' {
   import * as React from 'react';
   import {
-    Animated,
+    Animated as RNAnimated,
     ImageRequireSource,
     ImageURISource,
     NativeSyntheticEvent,
@@ -63,7 +63,7 @@ declare module 'react-native-maps' {
   // =======================================================================
 
   interface AnimatedRegionTimingConfig
-    extends Animated.AnimationConfig,
+    extends RNAnimated.AnimationConfig,
       Partial<Region> {
     easing?: (value: number) => number;
     duration?: number;
@@ -71,7 +71,7 @@ declare module 'react-native-maps' {
   }
 
   interface AnimatedRegionSpringConfig
-    extends Animated.AnimationConfig,
+    extends RNAnimated.AnimationConfig,
       Partial<Region> {
     overshootClamping?: boolean;
     restDisplacementThreshold?: number;
@@ -86,11 +86,11 @@ declare module 'react-native-maps' {
     damping?: number;
   }
 
-  export class AnimatedRegion extends Animated.AnimatedWithChildren {
-    latitude: Animated.Value;
-    longitude: Animated.Value;
-    latitudeDelta: Animated.Value;
-    longitudeDelta: Animated.Value;
+  export class AnimatedRegion extends RNAnimated.AnimatedWithChildren {
+    latitude: RNAnimated.Value;
+    longitude: RNAnimated.Value;
+    latitudeDelta: RNAnimated.Value;
+    longitudeDelta: RNAnimated.Value;
 
     constructor(region?: Region);
 
@@ -100,8 +100,8 @@ declare module 'react-native-maps' {
     stopAnimation(callback?: (region: Region) => void): void;
     addListener(callback: (region: Region) => void): string;
     removeListener(id: string): void;
-    spring(config: AnimatedRegionSpringConfig): Animated.CompositeAnimation;
-    timing(config: AnimatedRegionTimingConfig): Animated.CompositeAnimation;
+    spring(config: AnimatedRegionSpringConfig): RNAnimated.CompositeAnimation;
+    timing(config: AnimatedRegionTimingConfig): RNAnimated.CompositeAnimation;
   }
 
   // =======================================================================


### PR DESCRIPTION
When using Typescript in strict mode, it fails with this error:

```
error TS2440: Import declaration conflicts with local declaration of 'Animated'.
```

It is caused by the typings importing `Animated` from `react-native` while defining a local `Animated` class.
Using an import alias fixes the issue.

### Does any other open PR do the same thing?

No

### What issue is this PR fixing?

None, I directly opened the PR instead of an issue

### How did you test this PR?

We are using this updated typings in our app and TS compiler is no longer complaining.
