### PR TITLE
build(android): do not package android build directory

### DIFF
--- a/lib/android/.npmignore
+++ b/lib/android/.npmignore
@@ -1,0 +1,10 @@
+*.iml
+.DS_Store
+.gradle/
+.idea/
+.npmignore
+build/
+gradle/
+gradlew
+gradlew.bat
+local.properties


### PR DESCRIPTION
### Does any other open PR do the same thing?

No, no other PRs exist that I saw

### What issue is this PR fixing?

It was not logged. But I'm about to put a deprecation notice on the jetifier package and these files turned up as warnings, I thought I'd help you all get rid of them

### How did you test this PR?

On android if you use version 0.28.0, the gradle build runs jetifier and in the soon-to-be-release jetifier it emits warnings that this package has non-AndroidX files.

It turns out they are in `lib/android/build` which I thought was strange, but it appears the npm package step isn't ignoring them, so anyone might package them up when releasing

I maintain react-native-device-info and our android `.npmignore` file looks exactly like the one I propose here and has for quite some time - works great

https://github.com/react-native-device-info/react-native-device-info/blob/master/android/.npmignore

<!--
Thanks for your contribution :)
-->
