### PR TITLE
onMapLoaded missing type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -265,6 +265,7 @@ declare module 'react-native-maps' {
     compassOffset?: { x: number; y: number };
     tintColor?: string;
 
+    onMapLoaded?: () => void;
     onMapReady?: () => void;
     onKmlReady?: (values: KmlMapEvent) => void;
     onRegionChange?: (region: Region, details?: { isGesture: boolean }) => void;


### PR DESCRIPTION
### Does any other open PR do the same thing?

No

### What issue is this PR fixing?

Missing type for onMapLoaded property. Useful for typescript users

### How did you test this PR?

(please answer here)
