### PR TITLE
Add zIndex prop for Geojson to type declarations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -593,6 +593,7 @@ declare module 'react-native-maps' {
     lineCap?: 'butt' | 'round' | 'square';
     lineJoin?: 'miter' | 'round' | 'bevel';
     miterLimit?: number;
+    zIndex?: number;
   }
 
   export class Geojson extends React.Component<GeojsonProps, any> {}


### PR DESCRIPTION
If you use zIndex prop on `Geojson` component, you get typescript errors since it's not part of the declaration. 

### Does any other open PR do the same thing?

No

### What issue is this PR fixing?

I haven't seen an existing issue. I noticed this problem while working on my app.

### How did you test this PR?

I did this change on my project in node_modules and tried it out on iOS.