### PR TITLE
GeoJSON onPress Crash Fix and Marker Customization Options

### DIFF
--- a/docs/geojson.md
+++ b/docs/geojson.md
@@ -15,6 +15,7 @@
 | `miterLimit` | `Number`     |  | The limiting value that helps avoid spikes at junctions between connected line segments. The miter limit helps you avoid spikes in paths that use the `miter` `lineJoin` style. If the ratio of the miter length—that is, the diagonal length of the miter join—to the line thickness exceeds the miter limit, the joint is converted to a bevel join. The default miter limit is 10, which results in the conversion of miters whose angle at the joint is less than 11 degrees. |
 | `zIndex` | `Number`     |  | Layer level of the z-index value |
 | `onPress` | `Function`     |  | returns the selected overlay value with the onPress functionality |
+| `markerComponent` | `React Node`     |  | Component to render in place of the default marker when the overlay type is a `point` 
 
 ## Example
 

--- a/example/examples/Geojson.js
+++ b/example/examples/Geojson.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import MapView, { Geojson } from 'react-native-maps';
-
+import { StyleSheet, Text } from 'react-native';
 const myPlace = {
   type: 'FeatureCollection',
   features: [
@@ -16,7 +16,7 @@ const myPlace = {
 };
 
 const GeojsonMap = props => (
-  <MapView>
+  <MapView style={{...StyleSheet.absoluteFillObject}}>
     <Geojson geojson={myPlace} />
   </MapView>
 );

--- a/index.d.ts
+++ b/index.d.ts
@@ -594,6 +594,8 @@ declare module 'react-native-maps' {
     lineJoin?: 'miter' | 'round' | 'bevel';
     miterLimit?: number;
     zIndex?: number;
+    onPress?: (event: MapEvent) => void;
+    markerComponent?: React.ReactNode
   }
 
   export class Geojson extends React.Component<GeojsonProps, any> {}

--- a/lib/components/Geojson.js
+++ b/lib/components/Geojson.js
@@ -153,7 +153,7 @@ const Geojson = props => {
         const strokeWidth = getStrokeWidth(props, overlay);
         if (overlay.type === 'point') {
           return (
-           <Marker
+          <Marker
               key={index}
               coordinate={overlay.coordinates}
               image={props.image}

--- a/lib/components/Geojson.js
+++ b/lib/components/Geojson.js
@@ -153,7 +153,7 @@ const Geojson = props => {
         const strokeWidth = getStrokeWidth(props, overlay);
         if (overlay.type === 'point') {
           return (
-          <Marker
+            <Marker
               key={index}
               coordinate={overlay.coordinates}
               image={props.image}

--- a/lib/components/Geojson.js
+++ b/lib/components/Geojson.js
@@ -1,7 +1,171 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Marker from './MapMarker';
 import Polyline from './MapPolyline';
 import Polygon from './MapPolygon';
+import { ColorPropType } from 'react-native';
+
+const propTypes = {
+  /**
+   * [Geojson](https://geojson.org/) description of object.
+   */
+  geojson: PropTypes.object.isRequired,
+
+  /**
+   * The stroke color to use for the path.
+   */
+  strokeColor: ColorPropType,
+
+  /**
+   * The fill color to use for the path.
+   */
+  fillColor: ColorPropType,
+
+  /**
+   * The stroke width to use for the path.
+   */
+  strokeWidth: PropTypes.number,
+
+  /**
+   * The offset (in points) at which to start drawing the dash pattern.
+   *
+   * Use this property to start drawing a dashed line partway through a segment or gap. For
+   * example, a phase value of 6 for the patter 5-2-3-2 would cause drawing to begin in the
+   * middle of the first gap.
+   *
+   * The default value of this property is 0.
+   *
+   * @platform ios
+   */
+  lineDashPhase: PropTypes.number,
+
+  /**
+   * An array of numbers specifying the dash pattern to use for the path.
+   *
+   * The array contains one or more numbers that indicate the lengths (measured in points) of the
+   * line segments and gaps in the pattern. The values in the array alternate, starting with the
+   * first line segment length, followed by the first gap length, followed by the second line
+   * segment length, and so on.
+   *
+   * This property is set to `null` by default, which indicates no line dash pattern.
+   *
+   * @platform ios
+   */
+  lineDashPattern: PropTypes.arrayOf(PropTypes.number),
+
+  /**
+   * The line cap style to apply to the open ends of the path.
+   * The default style is `round`.
+   *
+   * @platform ios
+   */
+  lineCap: PropTypes.oneOf(['butt', 'round', 'square']),
+
+  /**
+   * The line join style to apply to corners of the path.
+   * The default style is `round`.
+   *
+   * @platform ios
+   */
+  lineJoin: PropTypes.oneOf(['miter', 'round', 'bevel']),
+
+  /**
+   * The limiting value that helps avoid spikes at junctions between connected line segments.
+   * The miter limit helps you avoid spikes in paths that use the `miter` `lineJoin` style. If
+   * the ratio of the miter length—that is, the diagonal length of the miter join—to the line
+   * thickness exceeds the miter limit, the joint is converted to a bevel join. The default
+   * miter limit is 10, which results in the conversion of miters whose angle at the joint
+   * is less than 11 degrees.
+   *
+   * @platform ios
+   */
+  miterLimit: PropTypes.number,
+
+  /**
+   * The order in which this tile overlay is drawn with respect to other overlays. An overlay
+   * with a larger z-index is drawn over overlays with smaller z-indices. The order of overlays
+   * with the same z-index is arbitrary. The default zIndex is 0.
+   *
+   * @platform android
+   */
+  zIndex: PropTypes.number,
+
+  /**
+   * Callback that is called when the user presses on the polygon
+   */
+  onPress: PropTypes.func,
+
+  /**
+   * Component to render in place of the default marker when the overlay type is a `point`
+   *
+   */
+  markerComponent: PropTypes.node,
+};
+
+const Geojson = props => {
+  const overlays = makeOverlays(props.geojson.features);
+  return (
+    <React.Fragment>
+      {overlays.map((overlay, index) => {
+        const fillColor = getColor(props, overlay, 'fill', 'fillColor');
+        const strokeColor = getColor(props, overlay, 'stroke', 'strokeColor');
+        const markerColor = getColor(props, overlay, 'marker-color', 'color');
+        const strokeWidth = getStrokeWidth(props, overlay);
+        if (overlay.type === 'point') {
+          return (
+            <Marker
+              key={index}
+              coordinate={overlay.coordinates}
+              image={props.image}
+              pinColor={markerColor}
+              zIndex={props.zIndex}
+              onPress={() => props.onPress && props.onPress(overlay)}
+            >
+              {props.markerComponent}
+            </Marker>
+          );
+        }
+        if (overlay.type === 'polygon') {
+          return (
+            <Polygon
+              key={index}
+              coordinates={overlay.coordinates}
+              holes={overlay.holes}
+              strokeColor={strokeColor}
+              fillColor={fillColor}
+              strokeWidth={strokeWidth}
+              tappable={props.tappable}
+              onPress={() => props.onPress && props.onPress(overlay)}
+              zIndex={props.zIndex}
+            />
+          );
+        }
+        if (overlay.type === 'polyline') {
+          return (
+            <Polyline
+              key={index}
+              coordinates={overlay.coordinates}
+              strokeColor={strokeColor}
+              strokeWidth={strokeWidth}
+              lineDashPhase={props.lineDashPhase}
+              lineDashPattern={props.lineDashPattern}
+              lineCap={props.lineCap}
+              lineJoin={props.lineJoin}
+              miterLimit={props.miterLimit}
+              zIndex={props.zIndex}
+              tappable={props.tappable}
+              onPress={() => props.onPress && props.onPress(overlay)}
+            />
+          );
+        }
+      })}
+    </React.Fragment>
+  );
+};
+
+Geojson.propTypes = propTypes;
+
+export default Geojson;
 
 export const makeOverlays = features => {
   const points = features
@@ -141,66 +305,3 @@ const getStrokeWidth = (props, overlay) => {
   }
   return 0;
 };
-
-const Geojson = props => {
-  const overlays = makeOverlays(props.geojson.features);
-  return (
-    <React.Fragment>
-      {overlays.map((overlay, index) => {
-        const fillColor = getColor(props, overlay, 'fill', 'fillColor');
-        const strokeColor = getColor(props, overlay, 'stroke', 'strokeColor');
-        const markerColor = getColor(props, overlay, 'marker-color', 'color');
-        const strokeWidth = getStrokeWidth(props, overlay);
-        if (overlay.type === 'point') {
-          return (
-            <Marker
-              key={index}
-              coordinate={overlay.coordinates}
-              image={props.image}
-              pinColor={markerColor}
-              zIndex={props.zIndex}
-              onPress={() => props.onPress && props.onPress(overlay)}
-            >
-              {props.markerChildren}
-            </Marker>
-          );
-        }
-        if (overlay.type === 'polygon') {
-          return (
-            <Polygon
-              key={index}
-              coordinates={overlay.coordinates}
-              holes={overlay.holes}
-              strokeColor={strokeColor}
-              fillColor={fillColor}
-              strokeWidth={strokeWidth}
-              tappable={props.tappable}
-              onPress={() => props.onPress && props.onPress(overlay)}
-              zIndex={props.zIndex}
-            />
-          );
-        }
-        if (overlay.type === 'polyline') {
-          return (
-            <Polyline
-              key={index}
-              coordinates={overlay.coordinates}
-              strokeColor={strokeColor}
-              strokeWidth={strokeWidth}
-              lineDashPhase={props.lineDashPhase}
-              lineDashPattern={props.lineDashPattern}
-              lineCap={props.lineCap}
-              lineJoin={props.lineJoin}
-              miterLimit={props.miterLimit}
-              zIndex={props.zIndex}
-              tappable={props.tappable}
-              onPress={() => props.onPress && props.onPress(overlay)}
-            />
-          );
-        }
-      })}
-    </React.Fragment>
-  );
-};
-
-export default Geojson;

--- a/lib/components/Geojson.js
+++ b/lib/components/Geojson.js
@@ -153,14 +153,16 @@ const Geojson = props => {
         const strokeWidth = getStrokeWidth(props, overlay);
         if (overlay.type === 'point') {
           return (
-            <Marker
+           <Marker
               key={index}
               coordinate={overlay.coordinates}
               image={props.image}
               pinColor={markerColor}
               zIndex={props.zIndex}
-              onPress={() => props.onPress(overlay)}
-            />
+              onPress={() => props.onPress && props.onPress(overlay)}
+            >
+              {props.markerChildren}
+            </Marker>
           );
         }
         if (overlay.type === 'polygon') {
@@ -173,7 +175,7 @@ const Geojson = props => {
               fillColor={fillColor}
               strokeWidth={strokeWidth}
               tappable={props.tappable}
-              onPress={() => props.onPress(overlay)}
+              onPress={() => props.onPress && props.onPress(overlay)}
               zIndex={props.zIndex}
             />
           );
@@ -192,7 +194,7 @@ const Geojson = props => {
               miterLimit={props.miterLimit}
               zIndex={props.zIndex}
               tappable={props.tappable}
-              onPress={() => props.onPress(overlay)}
+              onPress={() => props.onPress && props.onPress(overlay)}
             />
           );
         }


### PR DESCRIPTION


### Does any other open PR do the same thing?

No other PR has the same thing

### What issue is this PR fixing?

No issue right there, directly a fix and a new feature.

### How did you test this PR?

Tested on both iOS and Android with both simulators and real devices.

# What to do
## Bug Fix
This PR fixes the `GeoJSON`'s onPress undefined crash fix.

![CleanShot 2021-08-16 at 6 52 10@2x](https://user-images.githubusercontent.com/6813862/129594331-910db496-b821-4880-a338-ef92c7455ef6.png)


---------


## New Feature 

- GeoJSON has the default Marker for the `Point` however there are no `customization` options for the `GeoJSON`. Now it has the new prop option: `markerChildren` which receives any UI component for the new Marker Image.


### **Example:**

Big yellow Point markers are the default one and we could not customize its style in any way. Small-green Point markers are the new `Image` or `FastImage` any other UI component which can be customized by the dev itself.



<img width="488" alt="CleanShot 2021-08-16 at 6 58 42@2x" src="https://user-images.githubusercontent.com/6813862/129594711-0a1b94fa-e801-4331-8e4d-d7064ad1756c.png">

