### PR TITLE
Fix: polygon on press wrong coordinates

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -116,6 +116,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
   private FusedLocationSource fusedLocationSource;
 
   private ViewAttacherGroup attacherGroup;
+  private LatLng tapLocation;
 
   private static boolean contextHasBug(Context context) {
     return context == null ||
@@ -276,7 +277,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     map.setOnPolygonClickListener(new GoogleMap.OnPolygonClickListener() {
       @Override
       public void onPolygonClick(Polygon polygon) {
-        WritableMap event = makeClickEventData(polygon.getPoints().get(0));
+        WritableMap event = makeClickEventData(tapLocation);
         event.putString("action", "polygon-press");
         manager.pushEvent(context, polygonMap.get(polygon), "onPress", event);
       }
@@ -285,7 +286,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     map.setOnPolylineClickListener(new GoogleMap.OnPolylineClickListener() {
       @Override
       public void onPolylineClick(Polyline polyline) {
-        WritableMap event = makeClickEventData(polyline.getPoints().get(0));
+        WritableMap event = makeClickEventData(tapLocation);
         event.putString("action", "polyline-press");
         manager.pushEvent(context, polylineMap.get(polyline), "onPress", event);
       }
@@ -1007,6 +1008,10 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
   @Override
   public boolean dispatchTouchEvent(MotionEvent ev) {
     gestureDetector.onTouchEvent(ev);
+
+    int X = (int)ev.getX();          
+    int Y = (int)ev.getY();
+    tapLocation = map.getProjection().fromScreenLocation(new Point(X,Y));
 
     int action = MotionEventCompat.getActionMasked(ev);
 

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -286,7 +286,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     map.setOnPolylineClickListener(new GoogleMap.OnPolylineClickListener() {
       @Override
       public void onPolylineClick(Polyline polyline) {
-        WritableMap event = makeClickEventData(tapLocation);
+        WritableMap event = makeClickEventData(polyline.getPoints().get(0));
         event.putString("action", "polyline-press");
         manager.pushEvent(context, polylineMap.get(polyline), "onPress", event);
       }

--- a/lib/ios/AirMaps/AIRMapManager.m
+++ b/lib/ios/AirMaps/AIRMapManager.m
@@ -734,7 +734,11 @@ RCT_EXPORT_METHOD(getAddressFromCoordinates:(nonnull NSNumber *)reactTag
                 if (CGPathContainsPoint(mpr, NULL, mapPointAsCGP, FALSE)) {
                     id event = @{
                                 @"action": @"polygon-press",
-                                };
+                                @"coordinate": @{
+                                    @"latitude": @(tapCoordinate.latitude),
+                                    @"longitude": @(tapCoordinate.longitude),
+                                },
+                            };
                     polygon.onPress(event);
                 }
 


### PR DESCRIPTION
### Does any other open PR do the same thing?
No

### What issue is this PR fixing?
There are some issues regarding the _onPress_ on a polygon that returns the wrong coordinates:
- **android**: the coordinates of the first vertex of the polygon are returned and not those of the point where I clicked
- **ios**: coordinates are not returned

With my fix it is now possible to have a homogeneous behavior for ios and android and therefore it is possible to have the coordinates of the exact point where I tapped inside the polygon.

### How did you test this PR?
Tested on both iOS and Android with both simulators and real devices.