### PR TITLE
chore(podspec): bump the gmaps and gmaps-ios-utils versions to 3.7.0 and 3.0.0

### DIFF
--- a/react-native-google-maps.podspec
+++ b/react-native-google-maps.podspec
@@ -17,6 +17,6 @@ Pod::Spec.new do |s|
   s.compiler_flags = '-DHAVE_GOOGLE_MAPS=1', '-DHAVE_GOOGLE_MAPS_UTILS=1', '-fno-modules'
 
   s.dependency 'React-Core'
-  s.dependency 'GoogleMaps', '3.5.0'
-  s.dependency 'Google-Maps-iOS-Utils', '2.1.0'
+  s.dependency 'GoogleMaps', '3.7.0'
+  s.dependency 'Google-Maps-iOS-Utils', '3.0.0'
 end


### PR DESCRIPTION

Bumps the GoogleMaps version and Google-Maps-iOS-Utils versions to fix dependency bugs happening.
See #3893. Should be tested for the breaking change in Google-Maps-iOS-Utils 2.1.0 -> 3.0.0.

should resolve #3893

<!--
PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.

**What happens if you SKIP this step?**

Your pull request will NOT be evaluated!

PLEASE NOTE THAT PRs WITHOUT THE TEMPLATE IN PLACE WILL BE CLOSED RIGHT FROM THE START.

Thanks for helping us help you!
-->

### Does any other open PR do the same thing?

<!--
**Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**

If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)
 -->

No

### What issue is this PR fixing?

[3893](https://github.com/react-native-maps/react-native-maps/issues/3893)

### How did you test this PR?

<!--
Please let us know how you have verified that your changes work.

Ideally, your PR should contain a step-by-step test plan, so that reviewers can easily verify your changes.

Your PR will have much better chances of being merged if it is straightforward to verify.

Some questions you might want to think about:

- Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any?
- Did you test this on a real device, or in a simulator?
- Are there any platforms you were not able to test?
-->

Not sure how to test this correctly. `GoogleMaps` 3.5.0 -> 3.7.0 does not have any noteworthy changes. `Google-Maps-iOS-Utils` 2.1.0 -> 3.0.0 has a breaking change of: [Change GMUFeature properties type from NSString to NSObject](https://github.com/googlemaps/google-maps-ios-utils/commit/4a562be73ddd6f7181428f1d71d8930322e559a0). But I am not able to find any reference to that code. So this should probably be reviewed by someone that has some insights into the code to determine if it can be merged or not. 

<!--
Thanks for your contribution :)
-->
