### PR TITLE
Narrow GeojsonProps `geojson` prop to correspond to expectations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -596,7 +596,7 @@ declare module 'react-native-maps' {
   import GeoJSON from 'geojson';
 
   export interface GeojsonProps {
-    geojson: GeoJSON.GeoJSON;
+    geojson: GeoJSON.FeatureCollection;
     strokeColor?: string;
     fillColor?: string;
     strokeWidth?: number;


### PR DESCRIPTION
[This line](https://github.com/react-native-maps/react-native-maps/blob/b27b82e23105a32dcae8d8e296251d55856b04c5/lib/components/Geojson.js#L132) assumes the existence of the property `features` on object passed to the `geojson` prop. But the `features` property does not exist for `Geometry` or `Feature` types, so TS thinks it's allowable to pass those types even though they will cause the app to crash

<!--
PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.

**What happens if you SKIP this step?**

Your pull request will NOT be evaluated!

PLEASE NOTE THAT PRs WITHOUT THE TEMPLATE IN PLACE WILL BE CLOSED RIGHT FROM THE START.

Thanks for helping us help you!
-->

### Does any other open PR do the same thing?

<!--
**Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**

If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)
 -->

No

### What issue is this PR fixing?

- https://github.com/react-native-maps/react-native-maps/issues/3974

### How did you test this PR?

<!--
Please let us know how you have verified that your changes work.

Ideally, your PR should contain a step-by-step test plan, so that reviewers can easily verify your changes.

Your PR will have much better chances of being merged if it is straightforward to verify.

Some questions you might want to think about:

- Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any?
- Did you test this on a real device, or in a simulator?
- Are there any platforms you were not able to test?
-->

Manually overwrote the `index.d.ts` file in `node_modules` and found that TS began (correctly) complaining if I tried to pass something other than a `FeatureCollection` in the `geojson` prop.

<!--
Thanks for your contribution :)
-->
