### PR TITLE
Update Geojson.js 'tappable' prop type

### DIFF
--- a/lib/components/Geojson.js
+++ b/lib/components/Geojson.js
@@ -43,7 +43,7 @@ const propTypes = {
    * Make the `Polygon` or `Polyline` tappable
    *
    */
-  tappable: PropTypes.boolean,
+  tappable: PropTypes.bool,
 
   /**
    * An array of numbers specifying the dash pattern to use for the path.


### PR DESCRIPTION
### Does any other open PR do the same thing?

I don't think so. Although the proposed typescript re-write may supersede this change once merged

### What issue is this PR fixing?

'tappable' prop type should be "bool" not "boolean". This mistake causes warnings in typescript projects. See https://www.npmjs.com/package/prop-types#usage

### How did you test this PR?

Modifying the line in my own project's node_modules/react-native-maps make the error go away
