### PR TITLE
[ios] Fix: add coordinates to polygon onPress ios google maps

### DIFF
--- a/lib/ios/AirGoogleMaps/AIRGoogleMap.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMap.m
@@ -342,6 +342,21 @@ id regionAsJSON(MKCoordinateRegion region) {
 }
 
 - (void)didTapAtCoordinate:(CLLocationCoordinate2D)coordinate {
+  for (AIRGoogleMapPolygon *airPolygon in _polygons){
+    AIRGMSPolygon *polygon = airPolygon.polygon;
+    if(GMSGeometryContainsLocation(coordinate, polygon.path, polygon.geodesic)){
+        id event = @{@"action": @"polygon-press",
+                      @"id": polygon.identifier ?: @"unknown",
+                      @"coordinate": @{
+                          @"latitude": @(coordinate.latitude),
+                          @"longitude": @(coordinate.longitude),
+                        },
+                      };
+
+        if (polygon.onPress) polygon.onPress(event);
+        return;
+    }
+  }
   if (!self.onPress) return;
   self.onPress([self eventFromCoordinate:coordinate]);
 }

--- a/lib/ios/AirGoogleMaps/AIRGoogleMap.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMap.m
@@ -331,6 +331,7 @@ id regionAsJSON(MKCoordinateRegion region) {
    if (airPolyline.onPress) airPolyline.onPress(event);
 }
 
+// Suggestion to remove this method
 - (void)didTapPolygon:(GMSOverlay *)polygon {
     AIRGMSPolygon *airPolygon = (AIRGMSPolygon *)polygon;
 
@@ -338,14 +339,13 @@ id regionAsJSON(MKCoordinateRegion region) {
                  @"id": airPolygon.identifier ?: @"unknown",
                  };
 
-    // Suggestion to remove and use didTapAtCoordinate instead
-    // if (airPolygon.onPress) airPolygon.onPress(event);
+    if (airPolygon.onPress) airPolygon.onPress(event);
 }
 
 - (void)didTapAtCoordinate:(CLLocationCoordinate2D)coordinate {
   for (AIRGoogleMapPolygon *airPolygon in _polygons){
     AIRGMSPolygon *polygon = airPolygon.polygon;
-    if(GMSGeometryContainsLocation(coordinate, polygon.path, polygon.geodesic)){
+    if(GMSGeometryContainsLocation(coordinate, polygon.path, polygon.geodesic) && airPolygon.tappable){
         id event = @{@"action": @"polygon-press",
                       @"id": polygon.identifier ?: @"unknown",
                       @"coordinate": @{

--- a/lib/ios/AirGoogleMaps/AIRGoogleMap.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMap.m
@@ -338,7 +338,8 @@ id regionAsJSON(MKCoordinateRegion region) {
                  @"id": airPolygon.identifier ?: @"unknown",
                  };
 
-    if (airPolygon.onPress) airPolygon.onPress(event);
+    // Suggestion to remove and use didTapAtCoordinate instead
+    // if (airPolygon.onPress) airPolygon.onPress(event);
 }
 
 - (void)didTapAtCoordinate:(CLLocationCoordinate2D)coordinate {
@@ -354,6 +355,8 @@ id regionAsJSON(MKCoordinateRegion region) {
                       };
 
         if (polygon.onPress) polygon.onPress(event);
+        // Currently returning after the first match
+        // how do we want to handle overlaying polygons? Call one or all? Can change to accomodate
         return;
     }
   }

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapPolygon.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapPolygon.m
@@ -87,8 +87,9 @@
 
 -(void)setTappable:(BOOL)tappable
 {
-  _tappable = tappable;
-  _polygon.tappable = tappable;
+  // If tappable is off didTapAtCoordinate gets called, if it's on didTapOverlay get called instead
+  _tappable = !tappable;
+  _polygon.tappable = !tappable;
 }
 
 - (void)setOnPress:(RCTBubblingEventBlock)onPress {

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapPolygon.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapPolygon.m
@@ -87,9 +87,9 @@
 
 -(void)setTappable:(BOOL)tappable
 {
+  _tappable = tappable;
   // If tappable is off didTapAtCoordinate gets called, if it's on didTapOverlay get called instead
-  _tappable = !tappable;
-  _polygon.tappable = !tappable;
+  _polygon.tappable = NO;
 }
 
 - (void)setOnPress:(RCTBubblingEventBlock)onPress {


### PR DESCRIPTION
### Does any other open PR do the same thing?

No

### What issue is this PR fixing?

This PR fixed the issue raised on #4012. Regarding the Polygon onPress function not returning the tapped coordinates.

#3966 Added on fix for Android and iOS Apple Maps, but this functionality wasn't working on iOS Google Maps.

This PR is not yet finalised as it requires a discussion. At the moment the `onPress` event for the Polygon is triggered by the `didTapOverlay` method. This method does not offer a way to access the coordinates that the user has tapped. The only way of getting the coordinates is through the `didTapAtCoordinate`, but this method is not triggered inside a polygon if `tappable` is set to `true`.

My suggestion is to replace the use of `didTapOverlay` with `didTapAtCoordinate` to make Google Maps for iOS Polygon `onPress` event be consistent with the rest.

An SO answer going over the issue [here](https://stackoverflow.com/a/40583753/14702755).

I've left a few comments in the code. If happy with this approach I can proceed to finalise the PR. Same concept can also be applied to Polyline.

### How did you test this PR?

Tested on iOS with both simulators and real devices.
