### PR TITLE
[ios] Fix: Apple Maps calling onRegionChange while the map renders

### DIFF
--- a/lib/ios/AirMaps/AIRMapManager.m
+++ b/lib/ios/AirMaps/AIRMapManager.m
@@ -1045,7 +1045,11 @@ static int kDragCenterContext;
 
 - (void)mapView:(AIRMap *)mapView regionWillChangeAnimated:(__unused BOOL)animated
 {
-    [self _regionChanged:mapView];
+    // Don't send region did change events until map has
+    // started rendering, as these won't represent the final location
+    if(mapView.hasStartedRendering){
+        [self _regionChanged:mapView];
+    }
 
     AIRWeakTimerReference *weakTarget = [[AIRWeakTimerReference alloc] initWithTarget:self andSelector:@selector(_onTick:)];
     
@@ -1064,7 +1068,11 @@ static int kDragCenterContext;
     [mapView.regionChangeObserveTimer invalidate];
     mapView.regionChangeObserveTimer = nil;
 
-    [self _regionChanged:mapView];
+    // Don't send region did change events until map has
+    // started rendering, as these won't represent the final location
+    if(mapView.hasStartedRendering){
+        [self _regionChanged:mapView];
+    }
 
     if (zoomLevel < mapView.minZoomLevel) {
       [self setCenterCoordinate:[mapView centerCoordinate] zoomLevel:mapView.minZoomLevel animated:TRUE mapView:mapView];


### PR DESCRIPTION
### Does any other open PR do the same thing?

No.

### What issue is this PR fixing?

This PR is a fix for #4031. Two `onRegionChange` events where getting called while the Apple map was first rendering. Found out where this events were being triggered, and added a check not to call them until the map starts rendering which fixes the issue.

Now Apple maps behaves the same as google maps.

### How did you test this PR?

Tested on an iPhone 12 simulator running iOS 15.0