### PR TITLE
[android]: New Google Maps SDK Renderer

### DIFF
--- a/docs/mapview.md
+++ b/docs/mapview.md
@@ -12,6 +12,7 @@
 | `mapPadding` | `EdgePadding` |  | Adds custom padding to each side of the map. Useful when map elements/markers are obscured.
 | `paddingAdjustmentBehavior` | 'always' \| 'automatic' \| 'never' | 'never' | Indicates how/when to affect padding with safe area insets (`GoogleMaps` in iOS only)
 | `liteMode` | `Boolean` | `false` | Enable lite mode. **Note**: Android only.
+| `useNewRenderer` | `Boolean` | `false` | Enables the new [android renderer](https://developers.google.com/maps/documentation/android-sdk/renderer). The renderer can only be set once in your application, if this prop is true/false in the first rendered map all subsequent maps will be using the latest/legacy renderer. **Note**: Android only.
 | `mapType` | `String` | `"standard"` | The map type to be displayed. <br/><br/> - standard: standard road map (default)<br/> - none: no map **Note** Not available on MapKit<br/> - satellite: satellite view<br/> - hybrid: satellite view with roads and points of interest overlayed<br/> - terrain: topographic view<br/> - mutedStandard: more subtle, makes markers/lines pop more (iOS 11.0+ only)
 | `customMapStyle` | `Array` |  | Adds custom styling to the map component. See [README](https://github.com/react-native-maps/react-native-maps#customizing-the-map-style) for more information.
 | `userInterfaceStyle` | 'light' \| 'dark'  |  | Sets the map to the style selected.  Default is whatever the system settings is. **Note:** iOS Maps only (aka MapKit).

--- a/example/App.js
+++ b/example/App.js
@@ -53,6 +53,7 @@ import MassiveCustomMarkers from './examples/MassiveCustomMarkers';
 import GeojsonMap from './examples/Geojson';
 import CacheURLTiles from './examples/CacheURLTiles';
 import CacheWMSTiles from './examples/CacheWMSTiles';
+import NewRendererMap from './examples/NewRendererMap';
 
 const IOS = Platform.OS === 'ios';
 const ANDROID = Platform.OS === 'android';
@@ -163,6 +164,7 @@ export default class App extends React.Component<Props> {
         [FitToSuppliedMarkers, 'Focus Map On Markers', true],
         [FitToCoordinates, 'Fit Map To Coordinates', true],
         [LiteMapView, 'Android Lite MapView'],
+        [NewRendererMap, 'Android new renderer MapView'],
         [CustomTiles, 'Custom Tiles', true],
         [WMSTiles, 'WMS Tiles', true],
         [ZIndexMarkers, 'Position Markers with Z-index', true],

--- a/example/examples/NewRendererMap.js
+++ b/example/examples/NewRendererMap.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import { StyleSheet, View, Dimensions } from 'react-native';
+
+import MapView, { ProviderPropType } from 'react-native-maps';
+
+const { width, height } = Dimensions.get('window');
+
+const ASPECT_RATIO = width / height;
+const LATITUDE = 37.78825;
+const LONGITUDE = -122.4324;
+const LATITUDE_DELTA = 0.0922;
+const LONGITUDE_DELTA = LATITUDE_DELTA * ASPECT_RATIO;
+
+class NewRendererMap extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <View style={styles.container}>
+        <MapView
+          useNewRenderer
+          provider={this.props.provider}
+          style={styles.map}
+          initialRegion={{
+            latitude: LATITUDE,
+            longitude: LONGITUDE,
+            latitudeDelta: LATITUDE_DELTA,
+            longitudeDelta: LONGITUDE_DELTA,
+          }}
+        />
+      </View>
+    );
+  }
+}
+
+NewRendererMap.propTypes = {
+  provider: ProviderPropType,
+};
+
+const styles = StyleSheet.create({
+  container: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+  },
+  map: {
+    ...StyleSheet.absoluteFillObject,
+  },
+});
+
+export default NewRendererMap;

--- a/index.d.ts
+++ b/index.d.ts
@@ -259,6 +259,7 @@ declare module 'react-native-maps' {
     camera?: Camera;
     initialCamera?: Camera;
     liteMode?: boolean;
+    useNewRenderer?: boolean;
     mapPadding?: EdgePadding;
     paddingAdjustmentBehavior?: 'always' | 'automatic' | 'never';
     maxDelta?: number;

--- a/lib/android/build.gradle
+++ b/lib/android/build.gradle
@@ -25,9 +25,9 @@ dependencies {
   implementation('com.facebook.react:react-native:+') {
     exclude group: 'com.android.support'
   }
-  implementation "com.google.android.gms:play-services-base:${safeExtGet('playServicesVersion', '17.0.0')}"
-  implementation "com.google.android.gms:play-services-maps:${safeExtGet('playServicesVersion', '17.0.0')}"
-  implementation "com.google.android.gms:play-services-location:17.0.0"
+  implementation "com.google.android.gms:play-services-base:${safeExtGet('playServicesVersion', '18.0.0')}"
+  implementation "com.google.android.gms:play-services-maps:${safeExtGet('playServicesVersion', '18.0.0')}"
+  implementation "com.google.android.gms:play-services-location:18.0.0"
   implementation 'com.google.maps.android:android-maps-utils:0.5'
   implementation "androidx.work:work-runtime:$work_version"
 }

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapNewRendererManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapNewRendererManager.java
@@ -1,0 +1,32 @@
+package com.airbnb.android.react.maps;
+
+import android.util.Log;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.google.android.gms.maps.MapsInitializer;
+
+public class AirMapNewRendererManager extends AirMapManager {
+
+    private static final String REACT_CLASS = "AIRMapNewRenderer";
+    private final ReactApplicationContext appContext;
+
+    @Override
+    public String getName() {
+        return REACT_CLASS;
+    }
+
+    public AirMapNewRendererManager(ReactApplicationContext context) {
+        super(context);
+        this.appContext = context;
+    }
+
+    @Override
+    protected AirMapView createViewInstance(ThemedReactContext context) {
+        MapsInitializer.initialize(context, MapsInitializer.Renderer.LATEST, (MapsInitializer.Renderer renderer) -> {
+            Log.d("AirMapNewRenderer", renderer.toString());
+        });
+        return new AirMapView(context, this.appContext, this, googleMapOptions);
+    }
+
+}

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/MapsPackage.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/MapsPackage.java
@@ -39,6 +39,7 @@ public class MapsPackage implements ReactPackage {
     AirMapCircleManager circleManager = new AirMapCircleManager(reactContext);
     AirMapManager mapManager = new AirMapManager(reactContext);
     AirMapLiteManager mapLiteManager = new AirMapLiteManager(reactContext);
+    AirMapNewRendererManager mapNewRendererManager = new AirMapNewRendererManager(reactContext);
     AirMapUrlTileManager urlTileManager = new AirMapUrlTileManager(reactContext);
     AirMapWMSTileManager gsUrlTileManager = new AirMapWMSTileManager(reactContext);
     AirMapLocalTileManager localTileManager = new AirMapLocalTileManager(reactContext);
@@ -55,6 +56,7 @@ public class MapsPackage implements ReactPackage {
         circleManager,
         mapManager,
         mapLiteManager,
+        mapNewRendererManager,
         urlTileManager,
         gsUrlTileManager,
         localTileManager,

--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -382,6 +382,14 @@ const propTypes = {
   liteMode: PropTypes.bool,
 
   /**
+   * A Boolean indicating whether to use the new renderer for android
+   * Default value is `false`
+   *
+   * @platform android
+   */
+  useNewRenderer: PropTypes.bool,
+
+  /**
    * (Google Maps only)
    *
    * Padding that is used by the Google Map View to position
@@ -1050,6 +1058,17 @@ class MapView extends React.Component {
       );
     }
 
+    if (Platform.OS === 'android' && this.props.useNewRenderer) {
+      return (
+        <AirMapNewRenderer
+          ref={(ref) => {
+            this.map = ref;
+          }}
+          {...props}
+        />
+      );
+    }
+
     const AIRMap = getAirMapComponent(this.props.provider);
 
     return (
@@ -1091,6 +1110,8 @@ if (Platform.OS === 'android') {
       );
 }
 const getAirMapComponent = (provider) => airMaps[provider || 'default'];
+
+const AirMapNewRenderer = nativeComponent('AIRMapNewRenderer');
 
 let AIRMapLite;
 if (!NativeModules.UIManager.getViewManagerConfig) {


### PR DESCRIPTION
### Does any other open PR do the same thing?

No

### What issue is this PR fixing?

This PR provides access to the new Google Maps renderer on Android, as raised on #3991.

The new renderer can be enabled using the android prop `useNewRenderer`. The only thing to bear in mind is that the application will use the renderer of the first map that is used in your application, regardless of what this prop is past that first render. i.e. If the first map that shows in your application uses the latest renderer all other maps will use it. If the first map that shows in your application you uses the legacy renderer all other maps will use that one.

An alternative approach to this PR would be to have a method that you can call on your App.js to set the renderer at app start time. I've implemented both approaches but decided to go with the prop in the end. Ultimately this is a design decision and would like to get your feedback.

### How did you test this PR?

Tested it on a Samsung Galaxy Note 9. Also tested in on emulators that don't meet [google requirements](https://developers.google.com/maps/documentation/android-sdk/renderer) to verify that the legacy renderer was used as fallback.

<!--
Thanks for your contribution :)
-->
