### PR TITLE
[ios]: Add coordinates to Apple Maps Polyline onPress event

### DIFF
--- a/lib/ios/AirMaps/AIRMapManager.m
+++ b/lib/ios/AirMaps/AIRMapManager.m
@@ -778,8 +778,13 @@ RCT_EXPORT_METHOD(getAddressFromCoordinates:(nonnull NSNumber *)reactTag
     }
 
     if (nearestDistance <= maxMeters) {
+        AIRMapCoordinate *firstCoord = nearestPolyline.coordinates.firstObject;
         id event = @{
                    @"action": @"polyline-press",
+                   @"coordinate": @{
+                       @"latitude": @(firstCoord.coordinate.latitude),
+                       @"longitude": @(firstCoord.coordinate.longitude)
+                   }
                    };
         nearestPolyline.onPress(event);
     }


### PR DESCRIPTION
### Does any other open PR do the same thing?

No

### What issue is this PR fixing?

#4053 

### How did you test this PR?

The change is very small, but it can be tested like this:
1. Create a map
2. Add a polyline
3. Press it, and log the event to the console
4. The event object should contain the coordinates of the first point in the polyline, like the behavior on Android.

This affects Apple Maps on iOS. I tested it on a simulator.