### PR TITLE
Add MapView.__lastRegion to index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -302,6 +302,7 @@ declare module 'react-native-maps' {
   }
 
   export default class MapView extends React.Component<MapViewProps, any> {
+    private __lastRegion?: Region;
     getCamera(): Promise<Camera>;
     setCamera(camera: Partial<Camera>): void;
     animateCamera(camera: Partial<Camera>, opts?: { duration?: number }): void;


### PR DESCRIPTION
As suggested at https://github.com/react-native-maps/react-native-maps/issues/3906#issuecomment-933259986

### Does any other open PR do the same thing?

No

### What issue is this PR fixing?

#3906

### How did you test this PR?

Downloaded the sample code from the linked issue and uncommented the line that references __lastRegion. I get a TypeScript error in my editor that the field is supposed to be private, but I also see that Typescript is inferring the correct type for it.
