### PR TITLE
chore: add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "author": "Leland Richardson <leland.m.richardson@gmail.com>",
   "version": "0.30.1",
+  "license": "MIT",
   "scripts": {
     "lint": "./node_modules/eslint/bin/eslint.js .",
     "ci": "npm run lint",


### PR DESCRIPTION

### Does any other open PR do the same thing?

No

### What issue is this PR fixing?

Some license looking libs expecting to see a license field in the `package.json`

### How did you test this PR?

Run [lib](https://github.com/nodeshift/license-reporter) over my changes to find the MIT license.
