### PR TITLE
android: update work version to 2.7.1 (Android 12 support)

### DIFF
--- a/lib/android/build.gradle
+++ b/lib/android/build.gradle
@@ -8,7 +8,7 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
-  compileSdkVersion safeExtGet('compileSdkVersion', 28)
+  compileSdkVersion safeExtGet('compileSdkVersion', 31)
 
   defaultConfig {
     minSdkVersion safeExtGet('minSdkVersion', 21)
@@ -17,7 +17,7 @@ android {
 }
 
 dependencies {
-  def work_version = "2.5.0"
+  def work_version = "2.7.1"
   def supportLibVersion = safeExtGet('supportLibVersion', '28.0.0')
   def supportLibMajorVersion = supportLibVersion.split('\\.')[0] as int
   def appCompatLibName =  (supportLibMajorVersion < 20) ? "androidx.appcompat:appcompat" : "com.android.support:appcompat-v7"


### PR DESCRIPTION
### Does any other open PR do the same thing?

No

### What issue is this PR fixing?

When an Android app is built with `compileSdkVersion` >= 31 (Android 12) then `PendingIntent` objects need to have mutability specified (https://developer.android.com/about/versions/12/behavior-changes-12#pending-intent-mutability)

The Work library only does this starting with version 2.7.0. But this version also requires `compileSdkVersion` >= 31.

Without this change, when your app is configured with `compileSdkVersion < 31`,
it does not start at all and you get this message in debug logs

```
java.lang.IllegalArgumentException: com.myapp.myapp: Targeting S+ (version 10000 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.
    Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles.
        at android.app.PendingIntent.checkFlags(PendingIntent.java:386)
        at android.app.PendingIntent.getBroadcastAsUser(PendingIntent.java:657)
        at android.app.PendingIntent.getBroadcast(PendingIntent.java:644)
        at androidx.work.impl.utils.ForceStopRunnable.getPendingIntent(ForceStopRunnable.java:174)
        at androidx.work.impl.utils.ForceStopRunnable.isForceStopped(ForceStopRunnable.java:108)
        at androidx.work.impl.utils.ForceStopRunnable.run(ForceStopRunnable.java:86)
        at androidx.work.impl.utils.SerialExecutor$Task.run(SerialExecutor.java:75)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
        at java.lang.Thread.run(Thread.java:920)
```

### How did you test this PR?

I added `implementation "androidx.work:work-runtime:2.7.1"` in my app's `build.gradle` file. Gradle always forces the dependencies to use the highest requested version, so it override what is configured for this package.
After the change, my app starts fine.

### Alternatives

I guess this change is not ideal as it forces all apps using this package to set `compileSdkVersion = 31` and it can be an unwanted change. As the fix for `work` on Android 12 forces this, I am not sure there is a better way, except if you can check for the parent app `compileSdkVersion` value and switch the `work` version depending on it?

Another alternative would be to document this in the README until bumping `compileSdkVersion` is more mainstream.
