### PR TITLE
feat: migrate to deprecated-react-native-prop-types

### DIFF
--- a/lib/components/Geojson.js
+++ b/lib/components/Geojson.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Marker from './MapMarker';
 import Polyline from './MapPolyline';
 import Polygon from './MapPolygon';
-import { ColorPropType } from 'react-native';
+import { ColorPropType } from 'deprecated-react-native-prop-types';
 
 const propTypes = {
   /**

--- a/lib/components/MapCallout.js
+++ b/lib/components/MapCallout.js
@@ -1,16 +1,14 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { StyleSheet, ViewPropTypes, View } from 'react-native';
+import { StyleSheet } from 'react-native';
+import { ViewPropTypes } from 'deprecated-react-native-prop-types';
 import decorateMapComponent, {
   SUPPORTED,
   USES_DEFAULT_IMPLEMENTATION,
 } from './decorateMapComponent';
 
-// if ViewPropTypes is not defined fall back to View.propType (to support RN < 0.44)
-const viewPropTypes = ViewPropTypes || View.propTypes;
-
 const propTypes = {
-  ...viewPropTypes,
+  ...ViewPropTypes,
   tooltip: PropTypes.bool,
   onPress: PropTypes.func,
   alphaHitTest: PropTypes.bool,

--- a/lib/components/MapCalloutSubview.js
+++ b/lib/components/MapCalloutSubview.js
@@ -1,16 +1,14 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { StyleSheet, ViewPropTypes, View } from 'react-native';
+import { StyleSheet } from 'react-native';
+import { ViewPropTypes } from 'deprecated-react-native-prop-types';
 import decorateMapComponent, {
   SUPPORTED,
   NOT_SUPPORTED,
 } from './decorateMapComponent';
 
-// if ViewPropTypes is not defined fall back to View.propType (to support RN < 0.44)
-const viewPropTypes = ViewPropTypes || View.propTypes;
-
 const propTypes = {
-  ...viewPropTypes,
+  ...ViewPropTypes,
   onPress: PropTypes.func,
 };
 

--- a/lib/components/MapCircle.js
+++ b/lib/components/MapCircle.js
@@ -1,16 +1,16 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { ColorPropType, ViewPropTypes, View } from 'react-native';
+import {
+  ColorPropType,
+  ViewPropTypes,
+} from 'deprecated-react-native-prop-types';
 import decorateMapComponent, {
   USES_DEFAULT_IMPLEMENTATION,
   SUPPORTED,
 } from './decorateMapComponent';
 
-// if ViewPropTypes is not defined fall back to View.propType (to support RN < 0.44)
-const viewPropTypes = ViewPropTypes || View.propTypes;
-
 const propTypes = {
-  ...viewPropTypes,
+  ...ViewPropTypes,
 
   /**
    * The coordinate of the center of the circle

--- a/lib/components/MapHeatmap.js
+++ b/lib/components/MapHeatmap.js
@@ -1,16 +1,14 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { ViewPropTypes, View, processColor } from 'react-native';
+import { processColor } from 'react-native';
+import { ViewPropTypes } from 'deprecated-react-native-prop-types';
 import decorateMapComponent, {
   SUPPORTED,
   USES_DEFAULT_IMPLEMENTATION,
 } from './decorateMapComponent';
 
-// if ViewPropTypes is not defined fall back to View.propType (to support RN < 0.44)
-const viewPropTypes = ViewPropTypes || View.propTypes;
-
 const propTypes = {
-  ...viewPropTypes,
+  ...ViewPropTypes,
 
   /**
    * Array of heatmap entries to apply towards density.

--- a/lib/components/MapLocalTile.js
+++ b/lib/components/MapLocalTile.js
@@ -1,18 +1,14 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-
-import { ViewPropTypes, View } from 'react-native';
+import { ViewPropTypes } from 'deprecated-react-native-prop-types';
 
 import decorateMapComponent, {
   USES_DEFAULT_IMPLEMENTATION,
   SUPPORTED,
 } from './decorateMapComponent';
 
-// if ViewPropTypes is not defined fall back to View.propType (to support RN < 0.44)
-const viewPropTypes = ViewPropTypes || View.propTypes;
-
 const propTypes = {
-  ...viewPropTypes,
+  ...ViewPropTypes,
 
   /**
    * The path template of the local tile source.

--- a/lib/components/MapMarker.js
+++ b/lib/components/MapMarker.js
@@ -1,16 +1,17 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {
-  ColorPropType,
   StyleSheet,
   Platform,
   NativeModules,
   Animated,
   Image,
   findNodeHandle,
-  ViewPropTypes,
-  View,
 } from 'react-native';
+import {
+  ColorPropType,
+  ViewPropTypes,
+} from 'deprecated-react-native-prop-types';
 
 import decorateMapComponent, {
   SUPPORTED,
@@ -24,11 +25,8 @@ const viewConfig = {
   },
 };
 
-// if ViewPropTypes is not defined fall back to View.propType (to support RN < 0.44)
-const viewPropTypes = ViewPropTypes || View.propTypes;
-
 const propTypes = {
-  ...viewPropTypes,
+  ...ViewPropTypes,
 
   // TODO(lmr): get rid of these?
   identifier: PropTypes.string,

--- a/lib/components/MapOverlay.js
+++ b/lib/components/MapOverlay.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { View, StyleSheet, Image, Animated } from 'react-native';
+import { StyleSheet, Image, Animated } from 'react-native';
+import { ViewPropTypes } from 'deprecated-react-native-prop-types';
 
 import decorateMapComponent, {
   SUPPORTED,
@@ -15,7 +16,7 @@ const viewConfig = {
 };
 
 const propTypes = {
-  ...View.propTypes,
+  ...ViewPropTypes,
   // A custom image to be used as overlay.
   image: PropTypes.any.isRequired,
   // Top left and bottom right coordinates for the overlay

--- a/lib/components/MapPolygon.js
+++ b/lib/components/MapPolygon.js
@@ -1,17 +1,17 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { ColorPropType, ViewPropTypes, View } from 'react-native';
+import {
+  ColorPropType,
+  ViewPropTypes,
+} from 'deprecated-react-native-prop-types';
 import decorateMapComponent, {
   USES_DEFAULT_IMPLEMENTATION,
   SUPPORTED,
 } from './decorateMapComponent';
 import * as ProviderConstants from './ProviderConstants';
 
-// if ViewPropTypes is not defined fall back to View.propType (to support RN < 0.44)
-const viewPropTypes = ViewPropTypes || View.propTypes;
-
 const propTypes = {
-  ...viewPropTypes,
+  ...ViewPropTypes,
 
   /**
    * An array of coordinates to describe the polygon

--- a/lib/components/MapPolyline.js
+++ b/lib/components/MapPolyline.js
@@ -1,16 +1,16 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { ColorPropType, ViewPropTypes, View } from 'react-native';
+import {
+  ColorPropType,
+  ViewPropTypes,
+} from 'deprecated-react-native-prop-types';
 import decorateMapComponent, {
   USES_DEFAULT_IMPLEMENTATION,
   SUPPORTED,
 } from './decorateMapComponent';
 
-// if ViewPropTypes is not defined fall back to View.propType (to support RN < 0.44)
-const viewPropTypes = ViewPropTypes || View.propTypes;
-
 const propTypes = {
-  ...viewPropTypes,
+  ...ViewPropTypes,
 
   /**
    * An array of coordinates to describe the polygon

--- a/lib/components/MapUrlTile.js
+++ b/lib/components/MapUrlTile.js
@@ -1,18 +1,14 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-
-import { ViewPropTypes, View } from 'react-native';
+import { ViewPropTypes } from 'deprecated-react-native-prop-types';
 
 import decorateMapComponent, {
   USES_DEFAULT_IMPLEMENTATION,
   SUPPORTED,
 } from './decorateMapComponent';
 
-// if ViewPropTypes is not defined fall back to View.propType (to support RN < 0.44)
-const viewPropTypes = ViewPropTypes || View.propTypes;
-
 const propTypes = {
-  ...viewPropTypes,
+  ...ViewPropTypes,
 
   /**
    * The url template of the tile server. The patterns {x} {y} {z} will be replaced at runtime

--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -1,17 +1,18 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {
-  EdgeInsetsPropType,
-  PointPropType,
   Platform,
   Animated as RNAnimated,
   requireNativeComponent,
   NativeModules,
-  ColorPropType,
   findNodeHandle,
-  ViewPropTypes,
-  View,
 } from 'react-native';
+import {
+  EdgeInsetsPropType,
+  PointPropType,
+  ColorPropType,
+  ViewPropTypes,
+} from 'deprecated-react-native-prop-types';
 import MapMarker from './MapMarker';
 import MapPolyline from './MapPolyline';
 import MapPolygon from './MapPolygon';
@@ -65,11 +66,8 @@ const CameraShape = PropTypes.shape({
   zoom: PropTypes.number.isRequired,
 });
 
-// if ViewPropTypes is not defined fall back to View.propType (to support RN < 0.44)
-const viewPropTypes = ViewPropTypes || View.propTypes;
-
 const propTypes = {
-  ...viewPropTypes,
+  ...ViewPropTypes,
   /**
    * When provider is "google", we will use GoogleMaps.
    * Any value other than "google" will default to using
@@ -81,7 +79,7 @@ const propTypes = {
    * Used to style and layout the `MapView`.  See `StyleSheet.js` and
    * `ViewStylePropTypes.js` for more info.
    */
-  style: viewPropTypes.style,
+  style: ViewPropTypes.style,
 
   /**
    * A json object that describes the style of the map. This is transformed to a string

--- a/lib/components/MapWMSTile.js
+++ b/lib/components/MapWMSTile.js
@@ -1,18 +1,14 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-
-import { ViewPropTypes, View } from 'react-native';
+import { ViewPropTypes } from 'deprecated-react-native-prop-types';
 
 import decorateMapComponent, {
   USES_DEFAULT_IMPLEMENTATION,
   SUPPORTED,
 } from './decorateMapComponent';
 
-// if ViewPropTypes is not defined fall back to View.propType (to support RN < 0.44)
-const viewPropTypes = ViewPropTypes || View.propTypes;
-
 const propTypes = {
-  ...viewPropTypes,
+  ...ViewPropTypes,
 
   /**
    * The url template of the tile server. The patterns {minX} {maxX} {minY} {maxY} {width} {height}

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "typescript": "^4.4.3"
   },
   "dependencies": {
+    "deprecated-react-native-prop-types": "^2.3.0",
     "@types/geojson": "^7946.0.7"
   },
   "jest": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1200,6 +1200,11 @@
   resolved "https://registry.yarnpkg.com/@react-native/assets/-/assets-1.0.0.tgz#c6f9bf63d274bafc8e970628de24986b30a55c8e"
   integrity sha512-KrwSpS1tKI70wuKl68DwJZYEvXktDHdZMG0k2AXD/rJVSlB23/X2CB2cutVR0HwNMJIal9HOUOBB2rVfa6UGtQ==
 
+"@react-native/normalize-color@*":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@react-native/normalize-color/-/normalize-color-2.0.0.tgz#da955909432474a9a0fe1cbffc66576a0447f567"
+  integrity sha512-Wip/xsc5lw8vsBlmY2MO/gFLp3MvuZ2baBZjDeTjjndMgM0h5sxz7AZR62RDPGgstp8Np7JzjvVqVT7tpFZqsw==
+
 "@react-native/normalize-color@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@react-native/normalize-color/-/normalize-color-1.0.0.tgz#c52a99d4fe01049102d47dc45d40cbde4f720ab6"
@@ -2409,6 +2414,15 @@ depd@~1.1.2:
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
 
+deprecated-react-native-prop-types@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/deprecated-react-native-prop-types/-/deprecated-react-native-prop-types-2.3.0.tgz#c10c6ee75ff2b6de94bb127f142b814e6e08d9ab"
+  integrity sha512-pWD0voFtNYxrVqvBMYf5gq3NA2GCpfodS1yNynTPc93AYA/KEMGeWDqqeUB6R2Z9ZofVhks2aeJXiuQqKNpesA==
+  dependencies:
+    "@react-native/normalize-color" "*"
+    invariant "*"
+    prop-types "*"
+
 destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
@@ -3385,7 +3399,7 @@ internal-slot@^1.0.3:
     has "^1.0.3"
     side-channel "^1.0.4"
 
-invariant@^2.2.4:
+invariant@*, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -5381,6 +5395,15 @@ prompts@^2.0.1, prompts@^2.4.0:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
+prop-types@*:
+  version "15.8.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
+  integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.13.1"
+
 prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
@@ -5426,7 +5449,7 @@ react-devtools-core@^4.13.0:
     shell-quote "^1.6.1"
     ws "^7"
 
-react-is@^16.8.1:
+react-is@^16.13.1, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==


### PR DESCRIPTION
### Does any other open PR do the same thing?

No.

### What issue is this PR fixing?

`Image.propTypes`, `Text.propTypes`, `TextInput.propTypes`, `ColorPropType`, `EdgeInsetsPropType`, `PointPropType`, and `ViewPropTypes` from react-native are deprecated, and starting from react-native@0.68 using them will print a warning. They have already been removed in the main branch, so react-native@0.69 likely won't include them at all.

See: [react-native@0.68 changelog](https://github.com/facebook/react-native/blob/66419ed8f5be4e0efca4e0f261d902607408f29c/CHANGELOG.md#changed)

Suggested solution is to use the `deprecated-react-native-prop-types` package instead, which this PR does.

### How did you test this PR?

Installed react-native-maps in a react-native@0.68.0-rc.1 project, resulting in a lot of warning messages. After these changes, the warnings are no longer printed and the library continue to work as expected.