### PR TITLE
fix(android): initialRegion delay

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -91,6 +91,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
   private boolean handlePanDrag = false;
   private boolean moveOnMarkerPress = true;
   private boolean cacheEnabled = false;
+  private ReadableMap initialRegion;
   private boolean initialRegionSet = false;
   private boolean initialCameraSet = false;
   private LatLngBounds cameraLastIdleBounds;
@@ -218,6 +219,10 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     this.map.setOnMarkerDragListener(this);
     this.map.setOnPoiClickListener(this);
     this.map.setOnIndoorStateChangeListener(this);
+    if(initialRegion != null) {
+      setRegion(initialRegion);
+      initialRegionSet = true;
+    }
 
     manager.pushEvent(context, this, "onMapReady", new WritableNativeMap());
 
@@ -458,7 +463,10 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
   }
 
   public void setInitialRegion(ReadableMap initialRegion) {
-    if (!initialRegionSet && initialRegion != null) {
+    this.initialRegion = initialRegion;
+    // Theoretically onMapReady might be called before setInitialRegion
+    // In that case, trigger setRegion manually
+    if (!initialRegionSet && map != null) {
       setRegion(initialRegion);
       initialRegionSet = true;
     }

--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -1033,7 +1033,7 @@ class MapView extends React.Component {
       props = {
         style: this.props.style,
         region: null,
-        initialRegion: null,
+        initialRegion: this.props.initialRegion || null,
         onMarkerPress: this._onMarkerPress,
         onChange: this._onChange,
         onMapReady: this._onMapReady,


### PR DESCRIPTION
### Does any other open PR do the same thing?
No.

### What issue is this PR fixing?
#4060

Currently, initialRegion on Android takes a JS round trip after onMapReady before being set, which causes the issue described in #4060. This PR removes that round trip.

### How did you test this PR?
Tested on both a physical device and an emulator. I'm no longer able to reproduce #4060 after the change.