### PR TITLE
fix(android): android 12 crash

### DIFF
--- a/lib/android/build.gradle
+++ b/lib/android/build.gradle
@@ -17,7 +17,7 @@ android {
 }
 
 dependencies {
-  def work_version = "2.5.0"
+  def work_version = safeExtGet('targetSdkVersion', 27) < 31 ? "2.5.0" : "2.7.1"
   def supportLibVersion = safeExtGet('supportLibVersion', '28.0.0')
   def supportLibMajorVersion = supportLibVersion.split('\\.')[0] as int
   def appCompatLibName =  (supportLibMajorVersion < 20) ? "androidx.appcompat:appcompat" : "com.android.support:appcompat-v7"


### PR DESCRIPTION
### Does any other open PR do the same thing?
I failed at starting a discussion regarding #4080 so instead I'm opening this, with what I believe is a better solution (for now at least).
Doing a conditional upgrade allows anyone to update `react-native-maps` without requiring any changes, while also avoiding crashes in projects with `targetSdkVersion >= 31`.
Ideally, work should be put into testing whether the tile components works as expected with this new version, but I assume that a lot of consumers aren't using the tile components, and 'just' need their apps to not crash on Android 12. Either way, this change shouldn't leave anyone worse off than they are... :)

### How did you test this PR?
Implemented this change in `react-native@0.67` & `react-native@0.68` (`targetSdkVersion < 31` & `targetSdkVersion = 31`) projects, resulting in the expected `androidx.work` version being installed, and a lack of any crashes. Disclaimer: Neither of the projects used the tile components.