### PR TITLE
docs: fix readme code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ render() {
       region={this.state.region}
     />
     <OverlayComponent
-      style={{position: “absolute”, bottom: 50}}
+      style={{position: "absolute", bottom: 50}}
     />
   );
 }


### PR DESCRIPTION
It had the wrong kind of quotes. The old ones were not valid when copy-pasted.