### PR TITLE
[iOS] [MapKit] Releasing tiles cache when receiving out of memory warnings

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -748,6 +748,10 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
   }
 
   public void updateExtraData(Object extraData) {
+    if (getWidth() <= 0 || getHeight() <= 0){
+          // exception would be thrown otherwise  at line 765
+          return;
+    }
     // if boundsToMove is not null, we now have the MapView's width/height, so we can apply
     // a proper camera move
     if (boundsToMove != null) {

--- a/lib/ios/AirMaps/AIRMap.m
+++ b/lib/ios/AirMaps/AIRMap.m
@@ -88,8 +88,35 @@ const NSInteger AIRMapMaxZoomLevel = 20;
         self.minZoomLevel = 0;
         self.maxZoomLevel = AIRMapMaxZoomLevel;
         self.compassOffset = CGPointMake(0, 0);
+        [self listenToMemoryWarnings];
+
     }
     return self;
+}
+
+- (void) listenToMemoryWarnings
+{
+    __weak typeof(self) weakSelf = self;
+    static dispatch_once_t onceToken;
+    static dispatch_source_t source;
+    dispatch_once(&onceToken, ^{
+            source = dispatch_source_create(DISPATCH_SOURCE_TYPE_MEMORYPRESSURE, 0, DISPATCH_MEMORYPRESSURE_WARN|DISPATCH_MEMORYPRESSURE_CRITICAL, dispatch_get_main_queue());
+            dispatch_source_set_event_handler(source, ^{
+                [weakSelf handleMemoryWarning];
+            });
+            dispatch_resume(source);
+    });
+}
+
+- (void) handleMemoryWarning
+{
+    MKMapType type = self.mapType;
+    if (type == MKMapTypeSatellite){
+        self.mapType = MKMapTypeStandard;
+    } else {
+        self.mapType = MKMapTypeSatellite;
+    }
+    self.mapType = type;
 }
 
 - (void)dealloc


### PR DESCRIPTION
### Does any other open PR do the same thing?

NO

### What issue is this PR fixing?

No link, but we had constant out of memory issues in our app and we tested this fix and it's working as expected.
long story short, apple maps cache tiles aggressively and if the user is interacting a lot with the map, the app will have a lot of memory pressure.
The fix here, while not perfect (it causes map tiles to reload) it avoids a crash which is a worst case experience for the users.

### How did you test this PR?
Our production apps, and in debug mode in the simulator where debug mode / memory analyzer was used.


