### PR TITLE
fix android crash with update extra if map has no size yet

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -750,6 +750,10 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
   public void updateExtraData(Object extraData) {
     // if boundsToMove is not null, we now have the MapView's width/height, so we can apply
     // a proper camera move
+    if (getWidth() <= 0 || getHeight() <= 0){
+          // exception would be thrown otherwise  at line 765
+          return;
+    }
     if (boundsToMove != null) {
       HashMap<String, Float> data = (HashMap<String, Float>) extraData;
       int width = data.get("width") == null ? 0 : data.get("width").intValue();
@@ -1017,7 +1021,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
   public boolean dispatchTouchEvent(MotionEvent ev) {
     gestureDetector.onTouchEvent(ev);
 
-    int X = (int)ev.getX();          
+    int X = (int)ev.getX();
     int Y = (int)ev.getY();
     if(map != null) {
       tapLocation = map.getProjection().fromScreenLocation(new Point(X,Y));


### PR DESCRIPTION
### Does any other open PR do the same thing?
NO



### What issue is this PR fixing?

Android crash introduced on master where setExtras is being called before the mapView has been displayed

### How did you test this PR?

Android device, since the change is only for native android

