### PR TITLE
fix(ios): pod install failing with deployment target 11.0

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -50,6 +50,14 @@ If you want to enable Google Maps on iOS, obtain the Google API key and edit you
 
 The `[GMSServices provideAPIKey]` should be the **first call** of the method.
 
+Google Maps SDK for iOS requires iOS 12, so make sure that your deployment target is >= 12.0 in your iOS project settings.
+
+Also make sure that your Podfile deployment target is set to >= 12.0 at the top of your Podfile, eg:
+
+```ruby
+platform :ios, '12.0'
+```
+
 Add the following to your Podfile above the `use_native_modules!` function and run `pod install` in the ios folder:
 
 ```ruby

--- a/react-native-maps.podspec
+++ b/react-native-maps.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.authors      = { "intelligibabble" => "leland.m.richardson@gmail.com" }
   s.homepage     = "https://github.com/react-native-maps/react-native-maps#readme"
   s.license      = "MIT"
-  s.platform     = :ios, "12.0"
+  s.platform     = :ios, "11.0"
 
   s.source       = { :git => "https://github.com/react-native-maps/react-native-maps.git", :tag=> "v#{s.version}" }
   s.source_files  = "ios/AirMaps/**/*.{h,m}"


### PR DESCRIPTION
### Does any other open PR do the same thing?

<!--
**Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**

If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)
 -->

No.

### What issue is this PR fixing?

The deployment target in our podfiles got changed to 12.0 when the Google Maps SDK for iOS was bumped to 6.0 which dropped support for iOS 11. But it was changed in both the default podfile and the google maps podfile, meaning that a deployment target of >= 12.0 is required, even when not using Google Maps on iOS.

### How did you test this PR?

Installed and ran `react-native-maps` on iOS with deployment target 11.0 with Apple Maps only.
Installed and ran `react-native-maps` with the google maps pod on iOS with deployment target 12.0 with Apple Maps and Google Maps.