### PR TITLE
fix(types): export types that were present before v1

### DIFF
--- a/src/Geojson.tsx
+++ b/src/Geojson.tsx
@@ -10,14 +10,14 @@ import {
   Polygon,
   MultiPolygon,
 } from 'geojson';
-import Marker, {Props as MarkerProps} from './MapMarker';
-import {Props as PolygonProps} from './MapPolygon';
-import {Props as PolylineProps} from './MapPolyline';
+import Marker, {MapMarkerProps as MarkerProps} from './MapMarker';
+import {MapPolygonProps as PolygonProps} from './MapPolygon';
+import {MapPolylineProps as PolylineProps} from './MapPolyline';
 import Polyline from './MapPolyline';
 import MapPolygon from './MapPolygon';
 import {LatLng} from './sharedTypes';
 
-type Props = {
+export type GeojsonProps = {
   /**
    * The pincolor used on markers
    *
@@ -172,7 +172,7 @@ type Props = {
     | PolylineProps['zIndex'];
 };
 
-const Geojson = (props: Props) => {
+const Geojson = (props: GeojsonProps) => {
   const {
     geojson,
     strokeColor,
@@ -399,7 +399,10 @@ const getColor = (
   return undefined;
 };
 
-const getStrokeWidth = (prop: Props['strokeWidth'], overlay: Overlay) => {
+const getStrokeWidth = (
+  prop: GeojsonProps['strokeWidth'],
+  overlay: Overlay,
+) => {
   if (prop) {
     return prop;
   }

--- a/src/MapCallout.tsx
+++ b/src/MapCallout.tsx
@@ -10,7 +10,7 @@ import decorateMapComponent, {
 } from './decorateMapComponent';
 import {CalloutPressEvent} from './sharedTypes';
 
-type Props = ViewProps & {
+export type MapCalloutProps = ViewProps & {
   /**
    * If `true`, clicks on transparent areas in callout will be passed to map.
    *
@@ -39,9 +39,9 @@ type Props = ViewProps & {
   tooltip?: boolean;
 };
 
-type NativeProps = Props;
+type NativeProps = MapCalloutProps;
 
-export class MapCallout extends React.Component<Props> {
+export class MapCallout extends React.Component<MapCalloutProps> {
   // declaration only, as they are set through decorateMap
   declare context: React.ContextType<typeof ProviderContext>;
   getNativeComponent!: () => NativeComponent<NativeProps>;

--- a/src/MapCalloutSubview.tsx
+++ b/src/MapCalloutSubview.tsx
@@ -10,7 +10,7 @@ import decorateMapComponent, {
 } from './decorateMapComponent';
 import {Frame, Point} from './sharedTypes';
 
-type Props = ViewProps & {
+export type MapCalloutSubviewProps = ViewProps & {
   /**
    * Callback that is called when the user presses on this subview inside callout
    *
@@ -20,9 +20,9 @@ type Props = ViewProps & {
   onPress?: (event: CalloutSubviewPressEvent) => void;
 };
 
-type NativeProps = Props;
+type NativeProps = MapCalloutSubviewProps;
 
-export class MapCalloutSubview extends React.Component<Props> {
+export class MapCalloutSubview extends React.Component<MapCalloutSubviewProps> {
   // declaration only, as they are set through decorateMap
   declare context: React.ContextType<typeof ProviderContext>;
   getNativeComponent!: () => NativeComponent<NativeProps>;

--- a/src/MapCircle.tsx
+++ b/src/MapCircle.tsx
@@ -10,7 +10,7 @@ import decorateMapComponent, {
 } from './decorateMapComponent';
 import {LatLng, LineCapType, LineJoinType} from './sharedTypes';
 
-type Props = ViewProps & {
+export type MapCircleProps = ViewProps & {
   /**
    * The coordinates of the center of the circle.
    *
@@ -119,9 +119,9 @@ type Props = ViewProps & {
   zIndex?: number;
 };
 
-type NativeProps = Props & {ref: React.RefObject<View>};
+type NativeProps = MapCircleProps & {ref: React.RefObject<View>};
 
-export class MapCircle extends React.Component<Props> {
+export class MapCircle extends React.Component<MapCircleProps> {
   // declaration only, as they are set through decorateMap
   declare context: React.ContextType<typeof ProviderContext>;
   getNativeComponent!: () => NativeComponent<NativeProps>;
@@ -130,7 +130,7 @@ export class MapCircle extends React.Component<Props> {
 
   private circle: NativeProps['ref'];
 
-  constructor(props: Props) {
+  constructor(props: MapCircleProps) {
     super(props);
     this.circle = React.createRef<View>();
   }

--- a/src/MapHeatmap.tsx
+++ b/src/MapHeatmap.tsx
@@ -8,9 +8,10 @@ import decorateMapComponent, {
   UIManagerCommand,
   USES_DEFAULT_IMPLEMENTATION,
 } from './decorateMapComponent';
-import {LatLng, Modify} from './sharedTypes';
+import {LatLng} from './sharedTypes';
+import {Modify} from './sharedTypesInternal';
 
-type Props = ViewProps & {
+export type MapHeatmapProps = ViewProps & {
   gradient?: {
     /**
      * Resolution of color map -- number corresponding to the number of steps colors are interpolated into.
@@ -68,10 +69,10 @@ type Props = ViewProps & {
 };
 
 type NativeProps = Modify<
-  Props,
+  MapHeatmapProps,
   {
     gradient?: Modify<
-      Props['gradient'],
+      MapHeatmapProps['gradient'],
       {colors: (ProcessedColorValue | null | undefined)[]}
     >;
   }
@@ -79,7 +80,7 @@ type NativeProps = Modify<
   ref: React.RefObject<View>;
 };
 
-export class MapHeatmap extends React.Component<Props> {
+export class MapHeatmap extends React.Component<MapHeatmapProps> {
   // declaration only, as they are set through decorateMap
   declare context: React.ContextType<typeof ProviderContext>;
   getNativeComponent!: () => NativeComponent<NativeProps>;
@@ -88,7 +89,7 @@ export class MapHeatmap extends React.Component<Props> {
 
   private heatmap: NativeProps['ref'];
 
-  constructor(props: Props) {
+  constructor(props: MapHeatmapProps) {
     super(props);
     this.heatmap = React.createRef<View>();
   }

--- a/src/MapLocalTile.tsx
+++ b/src/MapLocalTile.tsx
@@ -10,7 +10,7 @@ import decorateMapComponent, {
   UIManagerCommand,
 } from './decorateMapComponent';
 
-type Props = ViewProps & {
+export type MapLocalTileProps = ViewProps & {
   /**
    * @platform iOS: Apple Maps only
    * @platform Android: Supported
@@ -36,9 +36,9 @@ type Props = ViewProps & {
   zIndex?: number;
 };
 
-type NativeProps = Props;
+type NativeProps = MapLocalTileProps;
 
-export class MapLocalTile extends React.Component<Props> {
+export class MapLocalTile extends React.Component<MapLocalTileProps> {
   // declaration only, as they are set through decorateMap
   declare context: React.ContextType<typeof ProviderContext>;
   getNativeComponent!: () => NativeComponent<NativeProps>;

--- a/src/MapMarker.tsx
+++ b/src/MapMarker.tsx
@@ -28,11 +28,11 @@ import {
   MarkerDragStartEndEvent,
   MarkerPressEvent,
   MarkerSelectEvent,
-  Modify,
   Point,
 } from './sharedTypes';
+import {Modify} from './sharedTypesInternal';
 
-export type Props = ViewProps & {
+export type MapMarkerProps = ViewProps & {
   /**
    * Sets the anchor point for the marker.
    * The anchor specifies the point in the icon image that is anchored to the marker's position on the Earth's surface.
@@ -317,16 +317,16 @@ export type Props = ViewProps & {
   zIndex?: number;
 };
 
-type OmittedProps = Omit<Props, 'stopPropagation'>;
+type OmittedProps = Omit<MapMarkerProps, 'stopPropagation'>;
 
 type NativeProps = Modify<
   OmittedProps,
-  {icon?: string; image?: Props['image'] | string}
+  {icon?: string; image?: MapMarkerProps['image'] | string}
 > & {
   ref: React.RefObject<View>;
 };
 
-export class MapMarker extends React.Component<Props> {
+export class MapMarker extends React.Component<MapMarkerProps> {
   // declaration only, as they are set through decorateMap
   declare context: React.ContextType<typeof ProviderContext>;
   getNativeComponent!: () => NativeComponent<NativeProps>;
@@ -337,7 +337,7 @@ export class MapMarker extends React.Component<Props> {
 
   private marker: NativeProps['ref'];
 
-  constructor(props: Props) {
+  constructor(props: MapMarkerProps) {
     super(props);
 
     this.marker = React.createRef<View>();

--- a/src/MapOverlay.tsx
+++ b/src/MapOverlay.tsx
@@ -17,9 +17,10 @@ import decorateMapComponent, {
   UIManagerCommand,
   USES_DEFAULT_IMPLEMENTATION,
 } from './decorateMapComponent';
-import {LatLng, Modify, Point} from './sharedTypes';
+import {LatLng, Point} from './sharedTypes';
+import {Modify} from './sharedTypesInternal';
 
-type Props = ViewProps & {
+export type MapOverlayProps = ViewProps & {
   /**
    * The bearing in degrees clockwise from north. Values outside the range [0, 360) will be normalized.
    *
@@ -73,9 +74,9 @@ type Props = ViewProps & {
   tappable?: boolean;
 };
 
-type NativeProps = Modify<Props, {image?: string}>;
+type NativeProps = Modify<MapOverlayProps, {image?: string}>;
 
-export class MapOverlay extends React.Component<Props> {
+export class MapOverlay extends React.Component<MapOverlayProps> {
   // declaration only, as they are set through decorateMap
   declare context: React.ContextType<typeof ProviderContext>;
   getNativeComponent!: () => NativeComponent<NativeProps>;

--- a/src/MapPolygon.tsx
+++ b/src/MapPolygon.tsx
@@ -11,7 +11,7 @@ import decorateMapComponent, {
 import * as ProviderConstants from './ProviderConstants';
 import {LatLng, LineCapType, LineJoinType, Point} from './sharedTypes';
 
-export type Props = ViewProps & {
+export type MapPolygonProps = ViewProps & {
   /**
    * An array of coordinates to describe the polygon
    *
@@ -145,9 +145,9 @@ export type Props = ViewProps & {
   zIndex?: number;
 };
 
-type NativeProps = Props & {ref: React.RefObject<View>};
+type NativeProps = MapPolygonProps & {ref: React.RefObject<View>};
 
-export class MapPolygon extends React.Component<Props> {
+export class MapPolygon extends React.Component<MapPolygonProps> {
   // declaration only, as they are set through decorateMap
   declare context: React.ContextType<typeof ProviderContext>;
   getNativeComponent!: () => NativeComponent<NativeProps>;
@@ -156,12 +156,12 @@ export class MapPolygon extends React.Component<Props> {
 
   private polygon: NativeProps['ref'];
 
-  constructor(props: Props) {
+  constructor(props: MapPolygonProps) {
     super(props);
     this.polygon = React.createRef<View>();
   }
 
-  setNativeProps(props: Partial<Props>) {
+  setNativeProps(props: Partial<MapPolygonProps>) {
     this.polygon.current?.setNativeProps(props);
   }
 
@@ -169,9 +169,9 @@ export class MapPolygon extends React.Component<Props> {
     return () => {
       const {fillColor, strokeColor, strokeWidth} = this.props;
       let polygonNativeProps: {
-        fillColor?: Props['fillColor'];
-        strokeColor?: Props['strokeColor'];
-        strokeWidth?: Props['strokeWidth'];
+        fillColor?: MapPolygonProps['fillColor'];
+        strokeColor?: MapPolygonProps['strokeColor'];
+        strokeWidth?: MapPolygonProps['strokeWidth'];
       } = {};
       if (fillColor) {
         polygonNativeProps.fillColor = fillColor;

--- a/src/MapPolyline.tsx
+++ b/src/MapPolyline.tsx
@@ -10,7 +10,7 @@ import decorateMapComponent, {
 } from './decorateMapComponent';
 import {LatLng, LineCapType, LineJoinType, Point} from './sharedTypes';
 
-export type Props = ViewProps & {
+export type MapPolylineProps = ViewProps & {
   /**
    * An array of coordinates to describe the polyline
    *
@@ -146,9 +146,9 @@ export type Props = ViewProps & {
   zIndex?: number;
 };
 
-type NativeProps = Props & {ref: React.RefObject<View>};
+type NativeProps = MapPolylineProps & {ref: React.RefObject<View>};
 
-export class MapPolyline extends React.Component<Props> {
+export class MapPolyline extends React.Component<MapPolylineProps> {
   // declaration only, as they are set through decorateMap
   declare context: React.ContextType<typeof ProviderContext>;
   getNativeComponent!: () => NativeComponent<NativeProps>;
@@ -157,7 +157,7 @@ export class MapPolyline extends React.Component<Props> {
 
   private polyline: NativeProps['ref'];
 
-  constructor(props: Props) {
+  constructor(props: MapPolylineProps) {
     super(props);
     this.polyline = React.createRef<View>();
   }

--- a/src/MapUrlTile.tsx
+++ b/src/MapUrlTile.tsx
@@ -10,7 +10,7 @@ import decorateMapComponent, {
 } from './decorateMapComponent';
 import {ViewProps} from 'react-native';
 
-type Props = ViewProps & {
+export type MapUrlTileProps = ViewProps & {
   /**
    * Doubles tile size from 256 to 512 utilising higher zoom levels
    * i.e loading 4 higher zoom level tiles and combining them for one high-resolution tile.
@@ -145,9 +145,9 @@ type Props = ViewProps & {
   zIndex?: number;
 };
 
-type NativeProps = Props;
+type NativeProps = MapUrlTileProps;
 
-export class MapUrlTile extends React.Component<Props> {
+export class MapUrlTile extends React.Component<MapUrlTileProps> {
   // declaration only, as they are set through decorateMap
   declare context: React.ContextType<typeof ProviderContext>;
   getNativeComponent!: () => NativeComponent<NativeProps>;

--- a/src/MapView.types.ts
+++ b/src/MapView.types.ts
@@ -1,0 +1,201 @@
+import {ClickEvent, LatLng, Point, Region} from './sharedTypes';
+import {NativeSyntheticEvent} from 'react-native';
+
+// All types in this file are directly exported with the package for external
+// use.
+
+export type Camera = {
+  /**
+   * Apple Maps
+   */
+  altitude?: number;
+  center: LatLng;
+  heading: number;
+  pitch: number;
+
+  /**
+   * Google Maps
+   */
+  zoom?: number;
+};
+
+export type MapStyleElement = {
+  featureType?: string;
+  elementType?: string;
+  stylers: object[];
+};
+
+export type EdgePadding = {
+  top: Number;
+  right: Number;
+  bottom: Number;
+  left: Number;
+};
+
+export type MapType =
+  | 'hybrid'
+  | 'mutedStandard'
+  | 'none'
+  | 'satellite'
+  | 'standard'
+  | 'terrain';
+
+export type MapTypes = {
+  STANDARD: 'standard';
+  SATELLITE: 'satellite';
+  HYBRID: 'hybrid';
+  TERRAIN: 'terrain';
+  NONE: 'none';
+  MUTEDSTANDARD: 'mutedStandard';
+};
+
+export type IndoorLevel = {
+  index: number;
+  name: string;
+  shortName: string;
+};
+
+export type ActiveIndoorLevel = {
+  activeLevelIndex: number;
+  name: string;
+  shortName: string;
+};
+
+export type IndoorLevelActivatedEvent = NativeSyntheticEvent<{
+  IndoorLevel: ActiveIndoorLevel;
+}>;
+
+export type IndoorBuilding = {
+  underground: boolean;
+  activeLevelIndex: number;
+  levels: IndoorLevel[];
+};
+
+export type IndoorBuildingEvent = NativeSyntheticEvent<{
+  IndoorBuilding: IndoorBuilding;
+}>;
+
+export type KmlMarker = {
+  id: string;
+  title: string;
+  description: string;
+  coordinate: LatLng;
+  position: Point;
+};
+
+export type KmlMapEvent = NativeSyntheticEvent<{markers: KmlMarker[]}>;
+
+export type LongPressEvent = ClickEvent<{
+  /**
+   * @platform Android
+   */
+  action?: 'long-press';
+}>;
+
+export type PanDragEvent = ClickEvent;
+
+export type PoiClickEvent = NativeSyntheticEvent<{
+  placeId: string;
+  name: string;
+  coordinate: LatLng;
+
+  /**
+   * @platform Android
+   */
+  position?: Point;
+}>;
+
+export type MapPressEvent = ClickEvent<{
+  /**
+   * @platform Android
+   */
+  action?: 'press';
+}>;
+
+export type Details = {
+  isGesture?: boolean;
+};
+
+export type UserLocationChangeEvent = NativeSyntheticEvent<{
+  coordinate?: LatLng & {
+    altitude: number;
+    timestamp: number;
+    accuracy: number;
+    speed: number;
+    heading: number;
+
+    /**
+     * @platform iOS
+     */
+    altitudeAccuracy?: number;
+
+    /**
+     * @platform Android
+     */
+    isFromMockProvider?: boolean;
+  };
+
+  /**
+   * @platform iOS
+   */
+  error?: {
+    message: string;
+  };
+}>;
+
+export type ChangeEvent = NativeSyntheticEvent<{
+  continuous: boolean;
+  region: Region;
+  isGesture?: boolean;
+}>;
+
+export type FitToOptions = {
+  edgePadding?: EdgePadding;
+  animated?: boolean;
+};
+
+export type BoundingBox = {northEast: LatLng; southWest: LatLng};
+
+export type SnapshotOptions = {
+  /** optional, when omitted the view-width is used */
+  width?: number;
+  /** optional, when omitted the view-height is used */
+  height?: number;
+  /** __iOS only__, optional region to render */
+  region?: Region;
+  /** image formats, defaults to 'png' */
+  format?: 'png' | 'jpg';
+  /** image quality: 0..1 (only relevant for jpg, default: 1) */
+  quality?: number;
+  /** result types, defaults to 'file' */
+  result?: 'file' | 'base64';
+};
+
+export type Address = {
+  administrativeArea: string;
+  country: string;
+  countryCode: string;
+  locality: string;
+  name: string;
+  postalCode: string;
+  subAdministrativeArea: string;
+  subLocality: string;
+  thoroughfare: string;
+};
+
+export type NativeCommandName =
+  | 'animateCamera'
+  | 'animateToRegion'
+  | 'coordinateForPoint'
+  | 'fitToCoordinates'
+  | 'fitToElements'
+  | 'fitToSuppliedMarkers'
+  | 'getAddressFromCoordinates'
+  | 'getCamera'
+  | 'getMapBoundaries'
+  | 'getMarkersFrames'
+  | 'pointForCoordinate'
+  | 'setCamera'
+  | 'setIndoorActiveLevelIndex'
+  | 'setMapBoundaries'
+  | 'takeSnapshot';

--- a/src/MapWMSTile.tsx
+++ b/src/MapWMSTile.tsx
@@ -10,7 +10,7 @@ import decorateMapComponent, {
   UIManagerCommand,
 } from './decorateMapComponent';
 
-type Props = ViewProps & {
+export type MapWMSTileProps = ViewProps & {
   /**
    * The maximum native zoom level for this tile overlay i.e. the highest zoom level that the tile server provides.
    * Tiles are auto-scaled for higher zoom levels.
@@ -124,9 +124,9 @@ type Props = ViewProps & {
   zIndex?: number;
 };
 
-type NativeProps = Props;
+type NativeProps = MapWMSTileProps;
 
-export class MapWMSTile extends React.Component<Props> {
+export class MapWMSTile extends React.Component<MapWMSTileProps> {
   // declaration only, as they are set through decorateMap
   declare context: React.ContextType<typeof ProviderContext>;
   getNativeComponent!: () => NativeComponent<NativeProps>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,26 +2,49 @@ import MapView, {
   AnimatedMapView as Animated,
   MAP_TYPES,
   enableLatestRenderer,
+  MapViewProps,
 } from './MapView';
-import Marker from './MapMarker';
-import Overlay from './MapOverlay';
 
-export {default as Polyline} from './MapPolyline';
-export {default as Heatmap} from './MapHeatmap';
-export {default as Polygon} from './MapPolygon';
-export {default as Circle} from './MapCircle';
-export {default as UrlTile} from './MapUrlTile';
-export {default as WMSTile} from './MapWMSTile';
-export {default as LocalTile} from './MapLocalTile';
-export {default as Callout} from './MapCallout';
-export {default as CalloutSubview} from './MapCalloutSubview';
+import Marker from './MapMarker';
+export {MapMarker} from './MapMarker';
+export type {MapMarkerProps} from './MapMarker';
+
+import Overlay from './MapOverlay';
+export {MapOverlay} from './MapOverlay';
+export type {MapOverlayProps} from './MapOverlay';
+
+export {default as Polyline, MapPolyline} from './MapPolyline';
+export type {MapPolylineProps} from './MapPolyline';
+export {default as Heatmap, MapHeatmap} from './MapHeatmap';
+export type {MapHeatmapProps} from './MapHeatmap';
+export {default as Polygon, MapPolygon} from './MapPolygon';
+export type {MapPolygonProps} from './MapPolygon';
+export {default as Circle, MapCircle} from './MapCircle';
+export type {MapCircleProps} from './MapCircle';
+export {default as UrlTile, MapUrlTile} from './MapUrlTile';
+export type {MapUrlTileProps} from './MapUrlTile';
+export {default as WMSTile, MapWMSTile} from './MapWMSTile';
+export type {MapWMSTileProps} from './MapWMSTile';
+export {default as LocalTile, MapLocalTile} from './MapLocalTile';
+export type {MapLocalTileProps} from './MapLocalTile';
+export {default as Callout, MapCallout} from './MapCallout';
+export type {MapCalloutProps} from './MapCallout';
+export {
+  default as CalloutSubview,
+  MapCalloutSubview,
+} from './MapCalloutSubview';
+export type {MapCalloutSubviewProps} from './MapCalloutSubview';
 export {default as AnimatedRegion} from './AnimatedRegion';
 export {default as Geojson} from './Geojson';
+export type {GeojsonProps} from './Geojson';
 
 export {Marker, Overlay};
+export type {MapViewProps};
 export {Animated, MAP_TYPES, enableLatestRenderer};
 
 export * from './ProviderConstants';
+export * from './MapView.types';
+export * from './sharedTypes';
 
 export const MarkerAnimated = Marker.Animated;
 export const OverlayAnimated = Overlay.Animated;

--- a/src/sharedTypes.ts
+++ b/src/sharedTypes.ts
@@ -1,7 +1,5 @@
 import {NativeSyntheticEvent} from 'react-native';
 
-export type Modify<T, R> = Omit<T, keyof R> & R;
-
 export type Provider = 'google' | undefined;
 
 export type LatLng = {

--- a/src/sharedTypesInternal.ts
+++ b/src/sharedTypesInternal.ts
@@ -1,0 +1,1 @@
+export type Modify<T, R> = Omit<T, keyof R> & R;


### PR DESCRIPTION
### Does any other open PR do the same thing?

No

### What issue is this PR fixing?

Many types are exported by the 0.31.1 of the library, but because we're now directly creating the `index.d.ts` from the actual Typescript, they're no longer exported.

This PR fixes this by:

1. Extracting all the types used by Props and callable functions into a `MapView.types.ts` and exporting those types
2. Exporting MapViewProps
3. Exporting all `sharedTypes.ts`
   - I moved the helper type `Modify` into a `sharedTypesInternal.ts` that's not exported
4. Exporting all the Props and inner components. The inner component types are useful for `React.createRef` and `useRef`

### How did you test this PR?

This is a pure typing change with no functionality change. I tested this by:

1. Creating a build of the package and installing it using `yarn add wanderlog/react-native-maps#407b2526384c6336f00ae094b518a34db9164a2c`
2. Build it and run it with the build of our app
   - We had to change a reference of MapEvent to PoiClickEvent, but otherwise it imported just fine