### PR TITLE
feat(ios-google): bump maps sdk to 7.0.0

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -46,12 +46,12 @@ If you want to enable Google Maps on iOS, obtain the Google API key and edit you
 
 The `[GMSServices provideAPIKey]` should be the **first call** of the method.
 
-Google Maps SDK for iOS requires iOS 12, so make sure that your deployment target is >= 12.0 in your iOS project settings.
+Google Maps SDK for iOS requires iOS 13, so make sure that your deployment target is >= 13.0 in your iOS project settings.
 
-Also make sure that your Podfile deployment target is set to >= 12.0 at the top of your Podfile, eg:
+Also make sure that your Podfile deployment target is set to >= 13.0 at the top of your Podfile, eg:
 
 ```ruby
-platform :ios, '12.0'
+platform :ios, '13.0'
 ```
 
 Add the following to your Podfile above the `use_native_modules!` function and run `pod install` in the ios folder:

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,7 +1,7 @@
 require_relative '../node_modules/react-native/scripts/react_native_pods'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
-platform :ios, '12.0'
+platform :ios, '13.0'
 
 target 'example' do
   config = use_native_modules!

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -90,10 +90,10 @@ PODS:
     - GoogleMaps
   - Google-Maps-iOS-Utils/QuadTree (4.1.0):
     - GoogleMaps
-  - GoogleMaps (6.2.1):
-    - GoogleMaps/Maps (= 6.2.1)
-  - GoogleMaps/Base (6.2.1)
-  - GoogleMaps/Maps (6.2.1):
+  - GoogleMaps (7.0.0):
+    - GoogleMaps/Maps (= 7.0.0)
+  - GoogleMaps/Base (7.0.0)
+  - GoogleMaps/Maps (7.0.0):
     - GoogleMaps/Base
   - libevent (2.1.12)
   - OpenSSL-Universal (1.1.180)
@@ -294,7 +294,7 @@ PODS:
   - React-jsinspector (0.65.1)
   - react-native-google-maps (1.0.0):
     - Google-Maps-iOS-Utils (= 4.1.0)
-    - GoogleMaps (= 6.2.1)
+    - GoogleMaps (= 7.0.0)
     - React-Core
   - react-native-maps (1.0.0):
     - React-Core
@@ -521,7 +521,7 @@ SPEC CHECKSUMS:
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 5337263514dd6f09803962437687240c5dc39aa4
   Google-Maps-iOS-Utils: 3343332b18dfd5be8f1f44edd7d481ace3da4d9a
-  GoogleMaps: 20d7b12be49a14287f797e88e0e31bc4156aaeb4
+  GoogleMaps: 6e9c923ca035989709fcb5771544fda4cc5fa2a4
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b
   RCT-Folly: 0dd9e1eb86348ecab5ba76f910b56f4b5fef3c46
@@ -535,7 +535,7 @@ SPEC CHECKSUMS:
   React-jsi: 12913c841713a15f64eabf5c9ad98592c0ec5940
   React-jsiexecutor: 43f2542aed3c26e42175b339f8d37fe3dd683765
   React-jsinspector: 41e58e5b8e3e0bf061fdf725b03f2144014a8fb0
-  react-native-google-maps: 2928d521689f4931543b6b3c68b2229e8455aa26
+  react-native-google-maps: 19813387e16fab7b8df7b7fe76f3fb848ca7a95a
   react-native-maps: 3639f68f0aec313db71de67a5c5fe5f755c529b3
   React-perflogger: fd28ee1f2b5b150b00043f0301d96bd417fdc339
   React-RCTActionSheet: 7f3fa0855c346aa5d7c60f9ced16e067db6d29fa
@@ -552,6 +552,6 @@ SPEC CHECKSUMS:
   Yoga: aa0cb45287ebe1004c02a13f279c55a95f1572f4
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 3e75f15a762d95604cf07c140bd34642e2243406
+PODFILE CHECKSUM: bc9df1be8f4ae04666ca85e6ee1e3b71014c6e12
 
 COCOAPODS: 1.11.2

--- a/react-native-google-maps.podspec
+++ b/react-native-google-maps.podspec
@@ -10,13 +10,13 @@ Pod::Spec.new do |s|
   s.authors      = { "intelligibabble" => "leland.m.richardson@gmail.com" }
   s.homepage     = "https://github.com/react-native-maps/react-native-maps#readme"
   s.license      = "MIT"
-  s.platform     = :ios, "12.0"
+  s.platform     = :ios, "13.0"
 
   s.source       = { :git => "https://github.com/react-native-maps/react-native-maps.git", :tag=> "v#{s.version}" }
   s.source_files  = "ios/AirGoogleMaps/**/*.{h,m}"
   s.compiler_flags = '-DHAVE_GOOGLE_MAPS=1', '-DHAVE_GOOGLE_MAPS_UTILS=1', '-fno-modules'
 
   s.dependency 'React-Core'
-  s.dependency 'GoogleMaps', '6.2.1'
+  s.dependency 'GoogleMaps', '7.0.0'
   s.dependency 'Google-Maps-iOS-Utils', '4.1.0'
 end


### PR DESCRIPTION
BREAKING CHANGE: Using Google Maps on iOS now requires iOS >= 13.0 and XCode >= 13

Description in commits.