### PR TITLE
fix(ios-google): crash when setting initialCamera prop

### DIFF
--- a/ios/AirGoogleMaps/AIRGoogleMap.h
+++ b/ios/AirGoogleMaps/AIRGoogleMap.h
@@ -22,7 +22,7 @@
 @property (nonatomic, assign) MKCoordinateRegion initialRegion;
 @property (nonatomic, assign) MKCoordinateRegion region;
 @property (nonatomic, assign) GMSCameraPosition *cameraProp;   // Because the base class already has a "camera" prop.
-@property (nonatomic, assign) GMSCameraPosition *initialCamera;
+@property (nonatomic, strong) GMSCameraPosition *initialCamera;
 @property (nonatomic, assign) NSString *customMapStyleString;
 @property (nonatomic, assign) UIEdgeInsets mapPadding;
 @property (nonatomic, assign) NSString *paddingAdjustmentBehaviorString;


### PR DESCRIPTION
initialCamera is accessed outside setter method, so property should have strong attribute.

Resolves #4321