### PR TITLE
fix(MapView): invalid parameter passed to nativemodule methods

### DIFF
--- a/src/MapView.tsx
+++ b/src/MapView.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {
   Animated as RNAnimated,
   Animated,
+  findNodeHandle,
   HostComponent,
   NativeModules,
   NativeSyntheticEvent,
@@ -761,7 +762,7 @@ class MapView extends React.Component<MapViewProps, State> {
 
   getCamera(): Promise<Camera> {
     if (Platform.OS === 'android') {
-      return NativeModules.AirMapModule.getCamera(this.map.current);
+      return NativeModules.AirMapModule.getCamera(this._getHandle());
     } else if (Platform.OS === 'ios') {
       return this._runCommand('getCamera', []);
     }
@@ -841,7 +842,7 @@ class MapView extends React.Component<MapViewProps, State> {
   async getMapBoundaries(): Promise<BoundingBox> {
     if (Platform.OS === 'android') {
       return await NativeModules.AirMapModule.getMapBoundaries(
-        this.map.current,
+        this._getHandle(),
       );
     } else if (Platform.OS === 'ios') {
       return await this._runCommand('getMapBoundaries', []);
@@ -894,7 +895,7 @@ class MapView extends React.Component<MapViewProps, State> {
 
     // Call native function
     if (Platform.OS === 'android') {
-      return NativeModules.AirMapModule.takeSnapshot(this.map.current, config);
+      return NativeModules.AirMapModule.takeSnapshot(this._getHandle(), config);
     } else if (Platform.OS === 'ios') {
       return new Promise((resolve, reject) => {
         this._runCommand('takeSnapshot', [
@@ -929,7 +930,7 @@ class MapView extends React.Component<MapViewProps, State> {
   addressForCoordinate(coordinate: LatLng): Promise<Address> {
     if (Platform.OS === 'android') {
       return NativeModules.AirMapModule.getAddressFromCoordinates(
-        this.map.current,
+        this._getHandle(),
         coordinate,
       );
     } else if (Platform.OS === 'ios') {
@@ -950,7 +951,7 @@ class MapView extends React.Component<MapViewProps, State> {
   pointForCoordinate(coordinate: LatLng): Promise<Point> {
     if (Platform.OS === 'android') {
       return NativeModules.AirMapModule.pointForCoordinate(
-        this.map.current,
+        this._getHandle(),
         coordinate,
       );
     } else if (Platform.OS === 'ios') {
@@ -971,7 +972,7 @@ class MapView extends React.Component<MapViewProps, State> {
   coordinateForPoint(point: Point): Promise<LatLng> {
     if (Platform.OS === 'android') {
       return NativeModules.AirMapModule.coordinateForPoint(
-        this.map.current,
+        this._getHandle(),
         point,
       );
     } else if (Platform.OS === 'ios') {
@@ -1022,9 +1023,13 @@ class MapView extends React.Component<MapViewProps, State> {
     ];
   }
 
+  private _getHandle() {
+    return findNodeHandle(this.map.current);
+  }
+
   private _runCommand(name: NativeCommandName, args: any[]) {
     if (Platform.OS === 'ios') {
-      return this._mapManagerCommand(name)(this.map.current, ...args);
+      return this._mapManagerCommand(name)(this._getHandle(), ...args);
     } else {
       return Promise.reject(`Invalid platform was passed: ${Platform.OS}`);
     }


### PR DESCRIPTION
This was introduced in 08ffc4ac398b38e0efe7c4d8da52e56f924f028d but since findNodeHandle is unused
in MapMarker I'm not reverting the entire commit.

Resolves #4415