### PR TITLE
docs: improve README link to drawables

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ import { Marker } from 'react-native-maps';
 ```
 
 ### Rendering a Marker with a custom image
-1. You need to generate an `png` image with various resolution (lets call them `custom_pin`) - for more information go to [Android](https://developer.android.com/studio/write/image-asset-studio#access), [iOS](https://developer.apple.com/documentation/xcode/adding-images-to-your-xcode-project)
+1. You need to generate an `png` image with various resolution (lets call them `custom_pin`) - for more information go to [Android](https://developer.android.com/studio/write/resource-manager#import), [iOS](https://developer.apple.com/documentation/xcode/adding-images-to-your-xcode-project)
 2. put all images in Android drawables and iOS assets dir 
 3. Now you can use the following code:
 ```jsx


### PR DESCRIPTION
<!--
PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.

**What happens if you SKIP this step?**

Your pull request will NOT be evaluated!

PLEASE NOTE THAT PRs WITHOUT THE TEMPLATE IN PLACE WILL BE CLOSED RIGHT FROM THE START.

Thanks for helping us help you!
-->

### Does any other open PR do the same thing?

No.

### What issue is this PR fixing?

[Existing link](https://developer.android.com/studio/write/image-asset-studio#access) to adding Android drawables points to adding Launcher icon, which is not what you want when adding images for markers. [This link seems](https://developer.android.com/studio/write/resource-manager#import) more accurate and helpful.

### How did you test this PR?

No testing.

<!--
Thanks for your contribution :)
-->
