### PR TITLE
fix: ios onRegionChange stops firing up when animateCamera is called …

### DIFF
--- a/ios/AirMaps/AIRMap.h
+++ b/ios/AirMaps/AIRMap.h
@@ -51,7 +51,7 @@ extern const NSInteger AIRMapMaxZoomLevel;
 @property (nonatomic, assign) MKCoordinateSpan pendingSpan;
 
 
-@property (nonatomic, assign) BOOL ignoreRegionChanges;
+@property (nonatomic, assign) NSInteger ignoreRegionChanges;
 
 @property (nonatomic, copy) RCTBubblingEventBlock onMapReady;
 @property (nonatomic, copy) RCTBubblingEventBlock onChange;

--- a/ios/AirMaps/AIRMap.m
+++ b/ios/AirMaps/AIRMap.m
@@ -87,6 +87,7 @@ const NSInteger AIRMapMaxZoomLevel = 20;
         self.minZoomLevel = 0;
         self.maxZoomLevel = AIRMapMaxZoomLevel;
         self.compassOffset = CGPointMake(0, 0);
+        self.ignoreRegionChanges = 0;
     }
     return self;
 }
@@ -258,13 +259,13 @@ const NSInteger AIRMapMaxZoomLevel = 20;
 
     CGPoint touchPoint = [self.calloutView convertPoint:point fromView:self];
     UIView *touchedView = [self.calloutView hitTest:touchPoint withEvent:event];
-    
+
     if (touchedView) {
         UIWindow* win = [[[UIApplication sharedApplication] windows] firstObject];
         AIRMapCalloutSubview* calloutSubview = nil;
         AIRMapCallout* callout = nil;
         AIRMapMarker* marker = nil;
-        
+
         UIView* tmp = touchedView;
         while (tmp && tmp != win && tmp != self.calloutView) {
             if ([tmp respondsToSelector:@selector(onPress)]) {
@@ -276,7 +277,7 @@ const NSInteger AIRMapMaxZoomLevel = 20;
             }
             tmp = tmp.superview;
         }
-        
+
         if (callout) {
             marker = [self markerForCallout:callout];
             if (marker) {
@@ -286,7 +287,7 @@ const NSInteger AIRMapMaxZoomLevel = 20;
                 }
             }
         }
-        
+
         return calloutSubview ? calloutSubview : touchedView;
     }
 
@@ -325,7 +326,7 @@ const NSInteger AIRMapMaxZoomLevel = 20;
 - (NSArray *)getMapBoundaries
 {
     MKMapRect mapRect = self.visibleMapRect;
-    
+
     CLLocationCoordinate2D northEast = MKCoordinateForMapPoint(MKMapPointMake(MKMapRectGetMaxX(mapRect), mapRect.origin.y));
     CLLocationCoordinate2D southWest = MKCoordinateForMapPoint(MKMapPointMake(mapRect.origin.x, MKMapRectGetMaxY(mapRect)));
 

--- a/ios/AirMaps/AIRMapManager.m
+++ b/ios/AirMaps/AIRMapManager.m
@@ -52,13 +52,13 @@ RCT_EXPORT_MODULE()
 
     map.isAccessibilityElement = NO;
     map.accessibilityElementsHidden = NO;
-    
+
     // MKMapView doesn't report tap events, so we attach gesture recognizers to it
     UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleMapTap:)];
     UITapGestureRecognizer *doubleTap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleMapDoubleTap:)];
     [doubleTap setNumberOfTapsRequired:2];
     [tap requireGestureRecognizerToFail:doubleTap];
-    
+
     UILongPressGestureRecognizer *longPress = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(handleMapLongPress:)];
     UIPanGestureRecognizer *drag = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(handleMapDrag:)];
     [drag setMinimumNumberOfTouches:1];
@@ -66,13 +66,13 @@ RCT_EXPORT_MODULE()
     tap.cancelsTouchesInView = NO;
     doubleTap.cancelsTouchesInView = NO;
     longPress.cancelsTouchesInView = NO;
-    
+
     doubleTap.delegate = self;
-    
+
     // disable drag by default
     drag.enabled = NO;
     drag.delegate = self;
-  
+
     [map addGestureRecognizer:tap];
     [map addGestureRecognizer:doubleTap];
     [map addGestureRecognizer:longPress];
@@ -129,20 +129,18 @@ RCT_CUSTOM_VIEW_PROPERTY(initialRegion, MKCoordinateRegion, AIRMap)
     if (json == nil) return;
 
     // don't emit region change events when we are setting the initialRegion
-    BOOL originalIgnore = view.ignoreRegionChanges;
-    view.ignoreRegionChanges = YES;
+    view.ignoreRegionChanges++;
     [view setInitialRegion:[RCTConvert MKCoordinateRegion:json]];
-    view.ignoreRegionChanges = originalIgnore;
+    view.ignoreRegionChanges--;
 }
 RCT_CUSTOM_VIEW_PROPERTY(initialCamera, MKMapCamera, AIRMap)
 {
     if (json == nil) return;
-    
+
     // don't emit region change events when we are setting the initialCamera
-    BOOL originalIgnore = view.ignoreRegionChanges;
-    view.ignoreRegionChanges = YES;
+    view.ignoreRegionChanges++;
     [view setInitialCamera:[RCTConvert MKMapCamera:json]];
-    view.ignoreRegionChanges = originalIgnore;
+    view.ignoreRegionChanges--;
 }
 
 
@@ -155,21 +153,19 @@ RCT_CUSTOM_VIEW_PROPERTY(region, MKCoordinateRegion, AIRMap)
     if (json == nil) return;
 
     // don't emit region change events when we are setting the region
-    BOOL originalIgnore = view.ignoreRegionChanges;
-    view.ignoreRegionChanges = YES;
+    view.ignoreRegionChanges++;
     [view setRegion:[RCTConvert MKCoordinateRegion:json] animated:NO];
-    view.ignoreRegionChanges = originalIgnore;
+    view.ignoreRegionChanges--;
 }
 
 RCT_CUSTOM_VIEW_PROPERTY(camera, MKMapCamera*, AIRMap)
 {
     if (json == nil) return;
-    
+
     // don't emit region change events when we are setting the camera
-    BOOL originalIgnore = view.ignoreRegionChanges;
-    view.ignoreRegionChanges = YES;
+    view.ignoreRegionChanges++;
     [view setCamera:[RCTConvert MKMapCamera:json] animated:NO];
-    view.ignoreRegionChanges = originalIgnore;
+    view.ignoreRegionChanges--;
 }
 
 
@@ -241,10 +237,9 @@ RCT_EXPORT_METHOD(setCamera:(nonnull NSNumber *)reactTag
             MKMapCamera *camera = [RCTConvert MKMapCameraWithDefaults:json existingCamera:[mapView camera]];
 
             // don't emit region change events when we are setting the camera
-            BOOL originalIgnore = mapView.ignoreRegionChanges;
-            mapView.ignoreRegionChanges = YES;
+            mapView.ignoreRegionChanges++;
             [mapView setCamera:camera animated:NO];
-            mapView.ignoreRegionChanges = originalIgnore;
+            mapView.ignoreRegionChanges--;
         }
     }];
 }
@@ -265,12 +260,11 @@ RCT_EXPORT_METHOD(animateCamera:(nonnull NSNumber *)reactTag
             MKMapCamera *camera = [RCTConvert MKMapCameraWithDefaults:json existingCamera:[mapView camera]];
 
             // don't emit region change events when we are setting the camera
-            BOOL originalIgnore = mapView.ignoreRegionChanges;
-            mapView.ignoreRegionChanges = YES;
+            mapView.ignoreRegionChanges++;
             [AIRMap animateWithDuration:duration/1000 animations:^{
                 [mapView setCamera:camera animated:YES];
             } completion:^(BOOL finished){
-                mapView.ignoreRegionChanges = originalIgnore;
+                mapView.ignoreRegionChanges--;
             }];
         }
     }];
@@ -549,16 +543,16 @@ RCT_EXPORT_METHOD(getAddressFromCoordinates:(nonnull NSNumber *)reactTag
                                   [overlay drawToSnapshot:snapshot context:UIGraphicsGetCurrentContext()];
                           }
                       }
-                      
+
                       for (id <MKAnnotation> annotation in mapView.annotations) {
                           CGPoint point = [snapshot pointForCoordinate:annotation.coordinate];
-                          
+
                           MKAnnotationView* anView = [mapView viewForAnnotation: annotation];
-                          
+
                           if (anView){
                               pin = anView;
                           }
-                          
+
                           if (CGRectContainsPoint(rect, point)) {
                               point.x = point.x + pin.centerOffset.x - (pin.bounds.size.width / 2.0f);
                               point.y = point.y + pin.centerOffset.y - (pin.bounds.size.height / 2.0f);
@@ -717,7 +711,7 @@ RCT_EXPORT_METHOD(getAddressFromCoordinates:(nonnull NSNumber *)reactTag
 - (void)handleMapDoubleTap:(UIPanGestureRecognizer*)recognizer {
     AIRMap *map = (AIRMap *)recognizer.view;
     if (!map.onDoublePress) return;
-    
+
     CGPoint touchPoint = [recognizer locationInView:map];
     CLLocationCoordinate2D coord = [map convertPoint:touchPoint toCoordinateFromView:map];
     map.onDoublePress(@{
@@ -730,7 +724,7 @@ RCT_EXPORT_METHOD(getAddressFromCoordinates:(nonnull NSNumber *)reactTag
                             @"y": @(touchPoint.y),
                             },
                     });
-    
+
 }
 
 
@@ -922,11 +916,11 @@ static int kDragCenterContext;
                          @"heading": @(location.location.course),
                          }
                  };
-    
+
     if (mapView.onUserLocationChange) {
         mapView.onUserLocationChange(event);
     }
-    
+
     if (mapView.followUserLocation) {
         MKCoordinateRegion region;
         region.span.latitudeDelta = AIRMapDefaultSpan;
@@ -937,7 +931,7 @@ static int kDragCenterContext;
         // Move to user location only for the first time it loads up.
         // mapView.followUserLocation = NO;
     }
-    
+
 }
 
 - (void)mapViewDidChangeVisibleRegion:(AIRMap *)mapView
@@ -1019,7 +1013,7 @@ static int kDragCenterContext;
 
 - (void)_emitRegionChangeEvent:(AIRMap *)mapView continuous:(BOOL)continuous
 {
-    if (!mapView.ignoreRegionChanges && mapView.onChange) {
+    if (mapView.ignoreRegionChanges == 0 && mapView.onChange) {
         MKCoordinateRegion region = mapView.region;
         if (!CLLocationCoordinate2DIsValid(region.center)) {
             return;


### PR DESCRIPTION
### Does any other open PR do the same thing?
No

### What issue is this PR fixing?
[IOS] onRegionChangeComplete is not firing up at all
(please link the issue here) #4110

### How did you test this PR?
On IOS, calling animate camera repeatedly, it never stops firing the event as before
Create a map, crete a flow of animateCamera called repeatedly, and print the result of onRegionChangeComplete
tested on simulator iPhone 13 iOs 15.4 and real device iPhone Xr iOs 15.5

