### PR TITLE
feat: require react-native >= 0.69.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ See [Setup Instructions for the Included Example Project](docs/examples-setup.md
 
 ## Compatibility
 
-`react-native-maps` requires `react-native >= 0.64.3`.
+`react-native-maps` requires `react-native >= 0.69.0`.
 
 ## Component API
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
       mavenCentral()
     }
     dependencies {
-      classpath("com.android.tools.build:gradle:4.2.2")
+      classpath("com.android.tools.build:gradle:7.1.1")
     }
   }
 }
@@ -29,17 +29,23 @@ android {
 }
 
 repositories {
-  mavenLocal()
-  mavenCentral()
   maven {
     // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-    url "$rootDir/../node_modules/react-native/android"
+    url("$rootDir/../node_modules/react-native/android")
   }
   maven {
     // Android JSC is installed from npm
-    url "$rootDir/../node_modules/jsc-android/dist"
+    url("$rootDir/../node_modules/jsc-android/dist")
+  }
+  mavenCentral {
+    // We don't want to fetch react-native from Maven Central as there are
+    // older versions over there.
+    content {
+      excludeGroup "com.facebook.react"
+    }
   }
   google()
+  maven { url 'https://www.jitpack.io' }
 }
 
 dependencies {

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     "mapkit"
   ],
   "peerDependencies": {
-    "react": ">= 17.0.1",
-    "react-native": ">= 0.64.3",
+    "react": ">= 18.0.0",
+    "react-native": ">= 0.69.0",
     "react-native-web": ">= 0.11"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
Aligns with official react-native support and prepares for fabric support.

BREAKING CHANGE: Drop support for react-native < 0.69.0