### PR TITLE
feat(android): use semantic version range for gradle dependencies

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,9 +44,34 @@ repositories {
 
 dependencies {
   implementation 'com.facebook.react:react-native:+'
-  implementation "com.google.android.gms:play-services-base:${safeExtGet('playServicesVersion', '18.1.0')}"
-  implementation "com.google.android.gms:play-services-maps:${safeExtGet('playServicesVersion', '18.0.2')}"
-  implementation "com.google.android.gms:play-services-location:20.0.0"
-  implementation 'com.google.maps.android:android-maps-utils:3.4.0'
-  implementation "androidx.work:work-runtime:2.7.1"
+  implementation('com.google.android.gms:play-services-base') {
+    version {
+      strictly '[18.0.1, 19.0.0['
+      prefer '18.1.0'
+    }
+  }
+  implementation('com.google.android.gms:play-services-maps') {
+    version {
+      strictly '[18.0.0, 19.0.0['
+      prefer '18.0.2'
+    }
+  }
+  implementation('com.google.android.gms:play-services-location') {
+    version {
+      strictly '[20.0.0, 21.0.0['
+      prefer '20.0.0'
+    }
+  }
+  implementation('com.google.maps.android:android-maps-utils') {
+    version {
+      strictly '[3.0.0, 4.0.0['
+      prefer '3.4.0'
+    }
+  }
+  implementation('androidx.work:work-runtime') {
+    version {
+      strictly '[2.7.1, 3.0.0['
+      prefer '2.7.1'
+    }
+  }
 }

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -90,9 +90,7 @@ Add your API key to your manifest file (`android/app/src/main/AndroidManifest.xm
 
 The installation documentation previously specified adding `supportLibVersion`, `playServicesVersion` and `androidMapsUtilsVersion` to `build.gradle`.
 
-None of these keys are required anymore and can be removed, if not used by other modules in your project.
-
-> **ATTENTION**: If you leave `playServicesVersion` in `build.gradle`, the version must be at least `18.0.0`
+None of these keys are used anymore and can be removed, if not in use by other modules in your project.
 
 ### Ensure that you have Google Play Services installed
 


### PR DESCRIPTION
BREAKING CHANGE: drop support for overriding play-services-{base,maps} version
