### PR TITLE
[iOS] Update Google-Maps-iOS-Utils to 4.2.2 to officialy support Apple Silicon without Rosetta

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -58,8 +58,6 @@ Add the following to your Podfile above the `use_native_modules!` function and r
 
 ```ruby
 # React Native Maps dependencies
-# The following line is only needed if building on an Apple silicon Mac without rosetta.
-pod 'Google-Maps-iOS-Utils', :git => 'https://github.com/Simon-TechForm/google-maps-ios-utils.git', :branch => 'feat/support-apple-silicon'
 
 rn_maps_path = '../node_modules/react-native-maps'
 pod 'react-native-google-maps', :path => rn_maps_path

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -26,7 +26,6 @@ target 'rnmshowcase' do
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )
 
-  pod 'Google-Maps-iOS-Utils', :git => 'https://github.com/Simon-TechForm/google-maps-ios-utils.git', :branch => 'feat/support-apple-silicon'
   rn_maps_path = '../../'
   pod 'react-native-google-maps', :path => rn_maps_path
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -11,24 +11,24 @@ PODS:
     - ReactCommon/turbomodule/core (= 0.70.9)
   - fmt (6.2.1)
   - glog (0.3.5)
-  - Google-Maps-iOS-Utils (4.2.0):
-    - Google-Maps-iOS-Utils/Clustering (= 4.2.0)
-    - Google-Maps-iOS-Utils/Geometry (= 4.2.0)
-    - Google-Maps-iOS-Utils/GeometryUtils (= 4.2.0)
-    - Google-Maps-iOS-Utils/Heatmap (= 4.2.0)
-    - Google-Maps-iOS-Utils/QuadTree (= 4.2.0)
+  - Google-Maps-iOS-Utils (4.2.2):
+    - Google-Maps-iOS-Utils/Clustering (= 4.2.2)
+    - Google-Maps-iOS-Utils/Geometry (= 4.2.2)
+    - Google-Maps-iOS-Utils/GeometryUtils (= 4.2.2)
+    - Google-Maps-iOS-Utils/Heatmap (= 4.2.2)
+    - Google-Maps-iOS-Utils/QuadTree (= 4.2.2)
     - GoogleMaps (~> 7.3)
-  - Google-Maps-iOS-Utils/Clustering (4.2.0):
+  - Google-Maps-iOS-Utils/Clustering (4.2.2):
     - Google-Maps-iOS-Utils/QuadTree
     - GoogleMaps (~> 7.3)
-  - Google-Maps-iOS-Utils/Geometry (4.2.0):
+  - Google-Maps-iOS-Utils/Geometry (4.2.2):
     - GoogleMaps (~> 7.3)
-  - Google-Maps-iOS-Utils/GeometryUtils (4.2.0):
+  - Google-Maps-iOS-Utils/GeometryUtils (4.2.2):
     - GoogleMaps (~> 7.3)
-  - Google-Maps-iOS-Utils/Heatmap (4.2.0):
+  - Google-Maps-iOS-Utils/Heatmap (4.2.2):
     - Google-Maps-iOS-Utils/QuadTree
     - GoogleMaps (~> 7.3)
-  - Google-Maps-iOS-Utils/QuadTree (4.2.0):
+  - Google-Maps-iOS-Utils/QuadTree (4.2.2):
     - GoogleMaps (~> 7.3)
   - GoogleMaps (7.4.0):
     - GoogleMaps/Maps (= 7.4.0)
@@ -264,7 +264,7 @@ PODS:
   - React-logger (0.70.9):
     - glog
   - react-native-google-maps (0.0.0):
-    - Google-Maps-iOS-Utils (= 4.2.0)
+    - Google-Maps-iOS-Utils (= 4.2.2)
     - GoogleMaps (= 7.4.0)
     - React-Core
   - react-native-maps (0.0.0):
@@ -465,7 +465,7 @@ SPEC CHECKSUMS:
   FBReactNativeSpec: 85d34420d92cb178897de05e3aba90e7a8568162
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
-  Google-Maps-iOS-Utils: d0921b7f1c4097e95fd8754fae6fd39d01dae01f
+  Google-Maps-iOS-Utils: f77eab4c4326d7e6a277f8e23a0232402731913a
   GoogleMaps: 032f676450ba0779bd8ce16840690915f84e57ac
   hermes-engine: 918ec5addfbc430c9f443376d739f088b6dc96c3
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
@@ -484,7 +484,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: d3f6d9242d4c93e7f0bdb27cb5510003bc98445c
   React-jsinspector: d76d32327f21d4f40dcf696231fdbbca60de4711
   React-logger: 1b3522f1e05c6360e93df3607a016c39e30a7351
-  react-native-google-maps: b17e5a80591c16795ffab7645f89ebb339adf666
+  react-native-google-maps: 89fa61970842d98bd01e9a271558c9f2a3f75c1c
   react-native-maps: 30d24060fb0abe9998d31a4cf37421ff14c59e25
   React-perflogger: cce000b5caa4bcecbb29ee9cfdb47f26202d2599
   React-RCTActionSheet: ba29f52a82d970e2aba5804490ecaea587c7a751
@@ -502,4 +502,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: bf7fecb2ed86ec74d17ea9980211210dac1ee632
 
-COCOAPODS: 1.12.0
+COCOAPODS: 1.12.1

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -11,25 +11,25 @@ PODS:
     - ReactCommon/turbomodule/core (= 0.70.9)
   - fmt (6.2.1)
   - glog (0.3.5)
-  - Google-Maps-iOS-Utils (4.1.0):
-    - Google-Maps-iOS-Utils/Clustering (= 4.1.0)
-    - Google-Maps-iOS-Utils/Geometry (= 4.1.0)
-    - Google-Maps-iOS-Utils/GeometryUtils (= 4.1.0)
-    - Google-Maps-iOS-Utils/Heatmap (= 4.1.0)
-    - Google-Maps-iOS-Utils/QuadTree (= 4.1.0)
-    - GoogleMaps
-  - Google-Maps-iOS-Utils/Clustering (4.1.0):
+  - Google-Maps-iOS-Utils (4.2.0):
+    - Google-Maps-iOS-Utils/Clustering (= 4.2.0)
+    - Google-Maps-iOS-Utils/Geometry (= 4.2.0)
+    - Google-Maps-iOS-Utils/GeometryUtils (= 4.2.0)
+    - Google-Maps-iOS-Utils/Heatmap (= 4.2.0)
+    - Google-Maps-iOS-Utils/QuadTree (= 4.2.0)
+    - GoogleMaps (~> 7.3)
+  - Google-Maps-iOS-Utils/Clustering (4.2.0):
     - Google-Maps-iOS-Utils/QuadTree
-    - GoogleMaps
-  - Google-Maps-iOS-Utils/Geometry (4.1.0):
-    - GoogleMaps
-  - Google-Maps-iOS-Utils/GeometryUtils (4.1.0):
-    - GoogleMaps
-  - Google-Maps-iOS-Utils/Heatmap (4.1.0):
+    - GoogleMaps (~> 7.3)
+  - Google-Maps-iOS-Utils/Geometry (4.2.0):
+    - GoogleMaps (~> 7.3)
+  - Google-Maps-iOS-Utils/GeometryUtils (4.2.0):
+    - GoogleMaps (~> 7.3)
+  - Google-Maps-iOS-Utils/Heatmap (4.2.0):
     - Google-Maps-iOS-Utils/QuadTree
-    - GoogleMaps
-  - Google-Maps-iOS-Utils/QuadTree (4.1.0):
-    - GoogleMaps
+    - GoogleMaps (~> 7.3)
+  - Google-Maps-iOS-Utils/QuadTree (4.2.0):
+    - GoogleMaps (~> 7.3)
   - GoogleMaps (7.4.0):
     - GoogleMaps/Maps (= 7.4.0)
   - GoogleMaps/Base (7.4.0)
@@ -264,7 +264,7 @@ PODS:
   - React-logger (0.70.9):
     - glog
   - react-native-google-maps (0.0.0):
-    - Google-Maps-iOS-Utils (= 4.1.0)
+    - Google-Maps-iOS-Utils (= 4.2.0)
     - GoogleMaps (= 7.4.0)
     - React-Core
   - react-native-maps (0.0.0):
@@ -343,7 +343,6 @@ DEPENDENCIES:
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
   - FBReactNativeSpec (from `../node_modules/react-native/React/FBReactNativeSpec`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
-  - Google-Maps-iOS-Utils (from `https://github.com/Simon-TechForm/google-maps-ios-utils.git`, branch `feat/support-apple-silicon`)
   - hermes-engine (from `../node_modules/react-native/sdks/hermes/hermes-engine.podspec`)
   - libevent (~> 2.1.12)
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
@@ -381,6 +380,7 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - fmt
+    - Google-Maps-iOS-Utils
     - GoogleMaps
     - libevent
 
@@ -395,9 +395,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/React/FBReactNativeSpec"
   glog:
     :podspec: "../node_modules/react-native/third-party-podspecs/glog.podspec"
-  Google-Maps-iOS-Utils:
-    :branch: feat/support-apple-silicon
-    :git: https://github.com/Simon-TechForm/google-maps-ios-utils.git
   hermes-engine:
     :podspec: "../node_modules/react-native/sdks/hermes/hermes-engine.podspec"
   RCT-Folly:
@@ -461,11 +458,6 @@ EXTERNAL SOURCES:
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
-CHECKOUT OPTIONS:
-  Google-Maps-iOS-Utils:
-    :commit: 35d05d1eeb65682c1b271f4f3760d814fd946aa1
-    :git: https://github.com/Simon-TechForm/google-maps-ios-utils.git
-
 SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
@@ -473,7 +465,7 @@ SPEC CHECKSUMS:
   FBReactNativeSpec: 85d34420d92cb178897de05e3aba90e7a8568162
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
-  Google-Maps-iOS-Utils: d3fdfd57db799771418f06189e33981597553aa8
+  Google-Maps-iOS-Utils: d0921b7f1c4097e95fd8754fae6fd39d01dae01f
   GoogleMaps: 032f676450ba0779bd8ce16840690915f84e57ac
   hermes-engine: 918ec5addfbc430c9f443376d739f088b6dc96c3
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
@@ -492,7 +484,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: d3f6d9242d4c93e7f0bdb27cb5510003bc98445c
   React-jsinspector: d76d32327f21d4f40dcf696231fdbbca60de4711
   React-logger: 1b3522f1e05c6360e93df3607a016c39e30a7351
-  react-native-google-maps: ee3ad79c32fda4f29fe9949e70e259bb31d7f849
+  react-native-google-maps: b17e5a80591c16795ffab7645f89ebb339adf666
   react-native-maps: 30d24060fb0abe9998d31a4cf37421ff14c59e25
   React-perflogger: cce000b5caa4bcecbb29ee9cfdb47f26202d2599
   React-RCTActionSheet: ba29f52a82d970e2aba5804490ecaea587c7a751
@@ -508,6 +500,6 @@ SPEC CHECKSUMS:
   ReactCommon: 153bd73ed963731a8e3e7f03a747b353fed7363e
   Yoga: dc109b79db907f0f589fc423e991b09ec42d2295
 
-PODFILE CHECKSUM: 1d755277e5648e128501c8fe0a40074bd2f373b1
+PODFILE CHECKSUM: bf7fecb2ed86ec74d17ea9980211210dac1ee632
 
-COCOAPODS: 1.12.1
+COCOAPODS: 1.12.0

--- a/example/ios/PodfileFrameworks
+++ b/example/ios/PodfileFrameworks
@@ -26,9 +26,7 @@ target 'rnmshowcase' do
     # An absolute path to your application root.
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )
-
-  # The following line is only needed if building on an Apple silicon Mac without rosetta.
-  pod 'Google-Maps-iOS-Utils', :git => 'https://github.com/Simon-TechForm/google-maps-ios-utils.git', :branch => 'feat/support-apple-silicon'
+  
   rn_maps_path = '../../'
   pod 'react-native-google-maps', :path => rn_maps_path
 

--- a/react-native-google-maps.podspec
+++ b/react-native-google-maps.podspec
@@ -18,5 +18,5 @@ Pod::Spec.new do |s|
 
   s.dependency 'React-Core'
   s.dependency 'GoogleMaps', '7.4.0'
-  s.dependency 'Google-Maps-iOS-Utils', '4.2.0'
+  s.dependency 'Google-Maps-iOS-Utils', '4.2.2'
 end

--- a/react-native-google-maps.podspec
+++ b/react-native-google-maps.podspec
@@ -18,5 +18,5 @@ Pod::Spec.new do |s|
 
   s.dependency 'React-Core'
   s.dependency 'GoogleMaps', '7.4.0'
-  s.dependency 'Google-Maps-iOS-Utils', '4.1.0'
+  s.dependency 'Google-Maps-iOS-Utils', '4.2.0'
 end


### PR DESCRIPTION
<!--
PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.

**What happens if you SKIP this step?**

Your pull request will NOT be evaluated!

PLEASE NOTE THAT PRs WITHOUT THE TEMPLATE IN PLACE WILL BE CLOSED RIGHT FROM THE START.

Thanks for helping us help you!
-->

### Does any other open PR do the same thing?

<!--
**Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**

If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)
 -->

No

### What issue is this PR fixing?

https://github.com/react-native-maps/react-native-maps/issues/4754

### How did you test this PR?

<!--
Please let us know how you have verified that your changes work.

Ideally, your PR should contain a step-by-step test plan, so that reviewers can easily verify your changes.

Your PR will have much better chances of being merged if it is straightforward to verify.

Some questions you might want to think about:

- Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any?
- Did you test this on a real device, or in a simulator?
- Are there any platforms you were not able to test?
-->

Tested on iOS from 13 to 16.5.1. 
App built on Intel and Apple Silicon machines. 

<!--
Thanks for your contribution :)
-->
