### PR TITLE
fix: issue with deprecated use of RCTEventEmitter in RegionChangeEvent

### DIFF
--- a/android/src/main/java/com/rnmaps/maps/MapView.java
+++ b/android/src/main/java/com/rnmaps/maps/MapView.java
@@ -30,6 +30,7 @@ import com.facebook.react.bridge.WritableNativeArray;
 import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.UIManagerHelper;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.events.EventDispatcher;
 import com.google.android.gms.maps.CameraUpdate;
@@ -377,10 +378,12 @@ public class MapView extends com.google.android.gms.maps.MapView implements Goog
 
         cameraLastIdleBounds = null;
         boolean isGesture = GoogleMap.OnCameraMoveStartedListener.REASON_GESTURE == cameraMoveReason;
+        int surfaceId = UIManagerHelper.getSurfaceId(context);
+        int tagId = getId();
 
-        RegionChangeEvent event = new RegionChangeEvent(getId(), bounds, true, isGesture);
-        eventDispatcher.dispatchEvent(event);
-      }
+        UIManagerHelper.getEventDispatcherForReactTag(context, tagId)
+                .dispatchEvent(
+                        new RegionChangeEvent(surfaceId, tagId, bounds, false, isGesture));      }
     });
 
     map.setOnCameraIdleListener(new GoogleMap.OnCameraIdleListener() {
@@ -393,10 +396,12 @@ public class MapView extends com.google.android.gms.maps.MapView implements Goog
 
           cameraLastIdleBounds = bounds;
           boolean isGesture = GoogleMap.OnCameraMoveStartedListener.REASON_GESTURE == cameraMoveReason;
+          int surfaceId = UIManagerHelper.getSurfaceId(context);
+          int tagId = getId();
 
-          RegionChangeEvent event = new RegionChangeEvent(getId(), bounds, false, isGesture);
-          eventDispatcher.dispatchEvent(event);
-        }
+          UIManagerHelper.getEventDispatcherForReactTag(context, tagId)
+                  .dispatchEvent(
+                          new RegionChangeEvent(surfaceId, tagId, bounds, false, isGesture));        }
       }
     });
 

--- a/android/src/main/java/com/rnmaps/maps/RegionChangeEvent.java
+++ b/android/src/main/java/com/rnmaps/maps/RegionChangeEvent.java
@@ -1,9 +1,9 @@
 package com.rnmaps.maps;
 
+import androidx.annotation.Nullable;
 import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.bridge.WritableNativeMap;
+import com.facebook.react.bridge.Arguments;
 import com.facebook.react.uimanager.events.Event;
-import com.facebook.react.uimanager.events.RCTEventEmitter;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.LatLngBounds;
 
@@ -12,8 +12,8 @@ public class RegionChangeEvent extends Event<RegionChangeEvent> {
   private final boolean continuous;
   private final boolean isGesture;
 
-  public RegionChangeEvent(int id, LatLngBounds bounds, boolean continuous, boolean isGesture) {
-    super(id);
+  public RegionChangeEvent(int surfaceId, int id, LatLngBounds bounds, boolean continuous, boolean isGesture) {
+    super(surfaceId, id);
     this.bounds = bounds;
     this.continuous = continuous;
     this.isGesture = isGesture;
@@ -29,20 +29,21 @@ public class RegionChangeEvent extends Event<RegionChangeEvent> {
     return false;
   }
 
+  @Nullable
   @Override
-  public void dispatch(RCTEventEmitter rctEventEmitter) {
-    WritableMap event = new WritableNativeMap();
-    event.putBoolean("continuous", continuous);
+  protected WritableMap getEventData() {
+    WritableMap eventData = Arguments.createMap(); //new WritableNativeMap();
+    eventData.putBoolean("continuous", continuous);
 
-    WritableMap region = new WritableNativeMap();
+    WritableMap region = Arguments.createMap();
     LatLng center = bounds.getCenter();
     region.putDouble("latitude", center.latitude);
     region.putDouble("longitude", center.longitude);
     region.putDouble("latitudeDelta", bounds.northeast.latitude - bounds.southwest.latitude);
     region.putDouble("longitudeDelta", bounds.northeast.longitude - bounds.southwest.longitude);
-    event.putMap("region", region);
-    event.putBoolean("isGesture", isGesture);
+    eventData.putMap("region", region);
+    eventData.putBoolean("isGesture", isGesture);
 
-    rctEventEmitter.receiveEvent(getViewTag(), getEventName(), event);
+    return eventData;
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-native-maps",
   "description": "React Native Mapview component for iOS + Android",
   "source": "src/index",
-  "main": "src/index.ts",
+  "main": "lib/index.js",
   "author": "Leland Richardson <leland.m.richardson@gmail.com>",
   "homepage": "https://github.com/react-native-maps/react-native-maps#readme",
   "version": "0.0.0",
@@ -14,6 +14,7 @@
     "build": "tsc --project tsconfig.build.json",
     "test": "jest",
     "prepare": "husky install",
+    "release": "semantic-release",
     "bundle-install": "cd example && bundle install",
     "pod-install": "cd example/ios && bundle exec pod install",
     "bootstrap": "yarn --cwd example && yarn && yarn bundle-install && yarn pod-install"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-native-maps",
   "description": "React Native Mapview component for iOS + Android",
   "source": "src/index",
-  "main": "lib/index.js",
+  "main": "src/index.ts",
   "author": "Leland Richardson <leland.m.richardson@gmail.com>",
   "homepage": "https://github.com/react-native-maps/react-native-maps#readme",
   "version": "0.0.0",
@@ -14,7 +14,6 @@
     "build": "tsc --project tsconfig.build.json",
     "test": "jest",
     "prepare": "husky install",
-    "release": "semantic-release",
     "bundle-install": "cd example && bundle install",
     "pod-install": "cd example/ios && bundle exec pod install",
     "bootstrap": "yarn --cwd example && yarn && yarn bundle-install && yarn pod-install"


### PR DESCRIPTION
<!--
PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.

**What happens if you SKIP this step?**

Your pull request will NOT be evaluated!

PLEASE NOTE THAT PRs WITHOUT THE TEMPLATE IN PLACE WILL BE CLOSED RIGHT FROM THE START.

Thanks for helping us help you!
-->

### Does any other open PR do the same thing?

<!--
**Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**

If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)
 -->

No

### What issue is this PR fixing?

There is an issue in emitting RegionChangeEvent event on Android with latest React Native version, it was using deprecated RCTEventEmitter, now replaced it with latest API

### How did you test this PR?

<!--
Please let us know how you have verified that your changes work.

Ideally, your PR should contain a step-by-step test plan, so that reviewers can easily verify your changes.

Your PR will have much better chances of being merged if it is straightforward to verify.

Some questions you might want to think about:

- Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any?
- Did you test this on a real device, or in a simulator?
- Are there any platforms you were not able to test?
-->

I tested it with integrating the library with test project

<!--
Thanks for your contribution :)
-->
