### PR TITLE
build(deps): bump play-services-location version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -46,7 +46,7 @@ dependencies {
   implementation 'com.facebook.react:react-native:+'
   implementation "com.google.android.gms:play-services-base:${safeExtGet('playServicesVersion', '18.1.0')}"
   implementation "com.google.android.gms:play-services-maps:${safeExtGet('playServicesVersion', '18.0.2')}"
-  implementation "com.google.android.gms:play-services-location:20.0.0"
+  implementation "com.google.android.gms:play-services-location:21.0.1"
   implementation 'com.google.maps.android:android-maps-utils:3.4.0'
   implementation "androidx.work:work-runtime:2.7.1"
 }


### PR DESCRIPTION
### Does any other open PR do the same thing?

No

### What issue is this PR fixing?

At Expo, we would like to bump the version of `gms:play-services-location` we use in `expo-location`. Doing this without bumping the version here will cause apps that have both libraries installed to crash.

### How did you test this PR?

`rnmshowcase` works as before. I went through the entire list of examples. Some of them have issues unrelated to the change in this PR.
