### PR TITLE
feat(android): Add android namespace to support react-native 0.73

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,6 +20,11 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+  if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
+    namespace "com.rnmaps.maps"
+  }
+
   compileSdkVersion safeExtGet('compileSdkVersion', 31)
 
   defaultConfig {


### PR DESCRIPTION
### Does any other open PR do the same thing?

No

### What issue is this PR fixing?

As stated here https://github.com/react-native-community/discussions-and-proposals/issues/671 React Native 0.73 will depend on Android Gradle Plugin (AGP) 8.x and this will require all the libraries to specify a namespace in their build.gradle file.

### How did you test this PR?

Build on android using AGP 8 


