### PR TITLE
fix(map): remove spamming warning from Map 

### DIFF
--- a/src/MapView.tsx
+++ b/src/MapView.tsx
@@ -731,9 +731,9 @@ class MapView extends React.Component<MapViewProps, State> {
    * See https://reactnative.dev/docs/new-architecture-library-intro#migrating-off-setnativeprops
    */
   setNativeProps(props: Partial<NativeProps>) {
-    console.warn(
-      'setNativeProps is deprecated and will be removed in next major release',
-    );
+    // console.warn(
+    //   'setNativeProps is deprecated and will be removed in next major release',
+    // );
     // @ts-ignore
     this.map.current?.setNativeProps(props);
   }


### PR DESCRIPTION
<!--
PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.

**What happens if you SKIP this step?**

Your pull request will NOT be evaluated!

PLEASE NOTE THAT PRs WITHOUT THE TEMPLATE IN PLACE WILL BE CLOSED RIGHT FROM THE START.

Thanks for helping us help you!
-->

### Does any other open PR do the same thing?

<!--
**Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**

If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)
 -->

Yes, this is very similar to https://github.com/react-native-maps/react-native-maps/pull/4644

### What issue is this PR fixing?

(https://github.com/react-native-maps/react-native-maps/issues/4536)

### How did you test this PR?

<!--
Please let us know how you have verified that your changes work.

Ideally, your PR should contain a step-by-step test plan, so that reviewers can easily verify your changes.

Your PR will have much better chances of being merged if it is straightforward to verify.

Some questions you might want to think about:

- Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any?
- Did you test this on a real device, or in a simulator?
- Are there any platforms you were not able to test?
-->

locally 
<!--
Thanks for your contribution :)
-->

Before fixing on IOS this looked like this:
<img src="https://github.com/react-native-maps/react-native-maps/assets/45079123/e2ddbb0b-8724-4260-b96f-f07d31296408" alt="drawing" width="200"/>
