### PR TITLE
4536: setNativeProps are supported in RN 0.72 and upwards in Fabric

### DIFF
--- a/src/MapMarker.tsx
+++ b/src/MapMarker.tsx
@@ -347,13 +347,7 @@ export class MapMarker extends React.Component<MapMarkerProps> {
     this.animateMarkerToCoordinate = this.animateMarkerToCoordinate.bind(this);
   }
 
-  /**
-   * @deprecated Will be removed in v2.0.0, as setNativeProps is not a thing in fabric.
-   * See https://reactnative.dev/docs/new-architecture-library-intro#migrating-off-setnativeprops
-   */
   setNativeProps(props: Partial<NativeProps>) {
-    // setNativeProps is deprecated and will be removed in next major release
-    // @ts-ignore
     this.marker.current?.setNativeProps(props);
   }
 

--- a/src/MapView.tsx
+++ b/src/MapView.tsx
@@ -726,15 +726,7 @@ class MapView extends React.Component<MapViewProps, State> {
     this._onChange = this._onChange.bind(this);
   }
 
-  /**
-   * @deprecated Will be removed in v2.0.0, as setNativeProps is not a thing in fabric.
-   * See https://reactnative.dev/docs/new-architecture-library-intro#migrating-off-setnativeprops
-   */
   setNativeProps(props: Partial<NativeProps>) {
-    console.warn(
-      'setNativeProps is deprecated and will be removed in next major release',
-    );
-    // @ts-ignore
     this.map.current?.setNativeProps(props);
   }
 


### PR DESCRIPTION
### Does any other open PR do the same thing?

No

### What issue is this PR fixing?

[4536](https://github.com/react-native-maps/react-native-maps/issues/4536)

### How did you test this PR?

it's a deletion of console log. I can't see testing needed.



