### PR TITLE
fix: crash due casting

### DIFF
--- a/ios/AirGoogleMaps/AIRGoogleMapMarker.m
+++ b/ios/AirGoogleMaps/AIRGoogleMapMarker.m
@@ -97,12 +97,12 @@ CGRect unionRect(CGRect a, CGRect b) {
 }
 
 - (void)removeReactSubview:(id<RCTComponent>)dummySubview {
-  UIView* subview = ((AIRDummyView*)dummySubview).view;
+   UIView *subview = [dummySubview isKindOfClass:[AIRDummyView class]] ? ((AIRDummyView *)dummySubview).view : (UIView *)dummySubview;
 
   if ([subview isKindOfClass:[AIRGoogleMapCallout class]]) {
     self.calloutView = nil;
   } else {
-    [(UIView*)subview removeFromSuperview];
+    [subview removeFromSuperview];
   }
   [super removeReactSubview:(UIView*)dummySubview];
 }


### PR DESCRIPTION

### Does any other open PR do the same thing?

Yes, [4824](https://github.com/react-native-maps/react-native-maps/pull/4824)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it



### What issue is this PR fixing?

https://github.com/react-native-maps/react-native-maps/issues/4823