### PR TITLE
Clarify documentation about customMapStyles being only effective with Google provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ render() {
 }
 ```
 
-### Customizing the map style
+### Customizing the map style (Google Maps provider only)
 
 Create the json object, or download a generated one from the [google style generator](https://mapstyle.withgoogle.com/).
 

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ render() {
 }
 ```
 
-For iOS, in addition to providing the `mapStyle` you will need to do the following
+This option only works with the Google provier. So for iOS, in addition to providing the `mapStyle` you will need to do specify the provier with the following:
 
 ```jsx
 import MapView, { PROVIDER_GOOGLE } from 'react-native-maps'


### PR DESCRIPTION

### Does any other open PR do the same thing?

<!--
**Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**

If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)
 -->

No

### What issue is this PR fixing?

[customMapStyle has no effect when using Apple maps as provider #4948](https://github.com/react-native-maps/react-native-maps/issues/4948)

### How did you test this PR?

<!--
Please let us know how you have verified that your changes work.

Ideally, your PR should contain a step-by-step test plan, so that reviewers can easily verify your changes.

Your PR will have much better chances of being merged if it is straightforward to verify.

Some questions you might want to think about:

- Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any?
- Did you test this on a real device, or in a simulator?
- Are there any platforms you were not able to test?
-->

This is a change in the Readme.

<!--
Thanks for your contribution :)
-->
