### PR TITLE
fix: use initialProps to set zoomTapEnabled in google-maps-ios

### DIFF
--- a/ios/AirGoogleMaps/AIRGoogleMap.h
+++ b/ios/AirGoogleMaps/AIRGoogleMap.h
@@ -81,7 +81,7 @@
 + (GMSCameraPosition*)makeGMSCameraPositionFromMap:(GMSMapView *)map andMKCoordinateRegion:(MKCoordinateRegion)region;
 
 - (NSDictionary*) getMarkersFramesWithOnlyVisible:(BOOL)onlyVisible;
-- (instancetype) initWithMapId:(NSString *) mapId;
+- (instancetype) initWithMapId:(NSString *) mapId andZoomTapEnabled:(BOOL) zoomTapEnabled;
 @end
 
 #endif

--- a/ios/AirGoogleMaps/AIRGoogleMap.m
+++ b/ios/AirGoogleMaps/AIRGoogleMap.m
@@ -71,7 +71,7 @@ id regionAsJSON(MKCoordinateRegion region) {
   NSString* _googleMapId;
 }
 
-- (instancetype)initWithMapId:(NSString *)mapId
+- (instancetype)initWithMapId:(NSString *)mapId andZoomTapEnabled:(BOOL)zoomTapEnabled
 {
     if (mapId){
         GMSMapID *mapID = [GMSMapID mapIDWithIdentifier:mapId];
@@ -100,7 +100,7 @@ id regionAsJSON(MKCoordinateRegion region) {
     _didLayoutSubviews = false;
     _didPrepareMap = false;
     _didCallOnMapReady = false;
-    _zoomTapEnabled = YES;
+    _zoomTapEnabled = zoomTapEnabled;
 
     // Listen to the myLocation property of GMSMapView.
     [self addObserver:self
@@ -116,7 +116,7 @@ id regionAsJSON(MKCoordinateRegion region) {
 }
 
 - (instancetype) init {
-  return [self initWithMapId:nil];
+  return [self initWithMapId:nil andZoomTapEnabled:YES];
 }
 
 - (void)dealloc {

--- a/ios/AirGoogleMaps/AIRGoogleMapManager.m
+++ b/ios/AirGoogleMaps/AIRGoogleMapManager.m
@@ -47,10 +47,16 @@ RCT_EXPORT_MODULE()
 {
   [GMSServices setMetalRendererEnabled:YES];
   NSString* googleMapId  = nil;
-  if (self.initialProps && self.initialProps[@"googleMapId"]){
-    googleMapId  = self.initialProps[@"googleMapId"];
+  BOOL zoomTapEnabled = YES;
+  if (self.initialProps){
+      if (self.initialProps[@"googleMapId"]){
+          googleMapId  = self.initialProps[@"googleMapId"];
+      }
+      if (self.initialProps[@"zoomTapEnabled"]){
+          zoomTapEnabled = self.initialProps[@"zoomTapEnabled"];
+      }
   }
-  AIRGoogleMap *map = [[AIRGoogleMap alloc] initWithMapId:googleMapId];
+  AIRGoogleMap *map = [[AIRGoogleMap alloc] initWithMapId:googleMapId andZoomTapEnabled:zoomTapEnabled];
   map.bridge = self.bridge;
   map.delegate = self;
   map.isAccessibilityElement = NO;


### PR DESCRIPTION
### Does any other open PR do the same thing?

https://github.com/react-native-maps/react-native-maps/pull/5026/

Yes, but the approach is different, this one simply makes sure that there is no race condition when setting up the mapview.

### What issue is this PR fixing?

https://github.com/react-native-maps/react-native-maps/issues/5024

### How did you test this PR?

Didn't, but this is a systematic approach so it should work
