### PR TITLE
fix(android): UIManagerModule fix for Bridgeless [0.74]

### DIFF
--- a/android/src/main/java/com/rnmaps/maps/MapModule.java
+++ b/android/src/main/java/com/rnmaps/maps/MapModule.java
@@ -16,11 +16,14 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.UIManager;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeMap;
+import com.facebook.react.fabric.FabricUIManager;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.uimanager.NativeViewHierarchyManager;
 import com.facebook.react.uimanager.UIBlock;
+import com.facebook.react.uimanager.UIManagerHelper;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.model.CameraPosition;
@@ -89,11 +92,15 @@ public class MapModule extends ReactContextBaseJavaModule {
         options.hasKey("height") ? (int) (displayMetrics.density * options.getDouble("height")) : 0;
     final String result = options.hasKey("result") ? options.getString("result") : "file";
 
-    // Add UI-block so we can get a valid reference to the map-view
-    UIManagerModule uiManager = context.getNativeModule(UIManagerModule.class);
-    uiManager.addUIBlock(new UIBlock() {
+    UIBlockInterface uiBlock = new UIBlockInterface() {
       public void execute(NativeViewHierarchyManager nvhm) {
-        MapView view = (MapView) nvhm.resolveView(tag);
+        executeImpl(nvhm, null);
+      }
+      public void execute(UIManagerViewResolver uiBlockViewResolver) {
+        executeImpl(null, uiBlockViewResolver);
+      }
+      public void executeImpl(NativeViewHierarchyManager nvhm, UIBlockViewResolver uiBlockViewResolver) {
+        MapView view = (MapView) uiBlockViewResolver != null ? uiBlockViewResolver.resolveView(tag) : nvhm.resolveView(tag);
         if (view == null) {
           promise.reject("AirMapView not found");
           return;
@@ -142,20 +149,32 @@ public class MapModule extends ReactContextBaseJavaModule {
           }
         });
       }
-    });
+    };
+
+    // Add UI-block so we can get a valid reference to the map-view
+
+    if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
+      UIManager uiManager = UIManagerHelper.getUIManager(context, UIManagerType.FABRIC);
+      ((FabricUIManager)uiManager).addUIBlock(uiBlock);
+    } else {
+      UIManagerModule uiManager = context.getNativeModule(UIManagerModule.class);
+      uiManager.addUIBlock(uiBlock);
+    }
   }
 
   @ReactMethod
   public void getCamera(final int tag, final Promise promise) {
     final ReactApplicationContext context = getReactApplicationContext();
 
-    UIManagerModule uiManager = context.getNativeModule(UIManagerModule.class);
-    uiManager.addUIBlock(new UIBlock()
-    {
-      @Override
-      public void execute(NativeViewHierarchyManager nvhm)
-      {
-        MapView view = (MapView) nvhm.resolveView(tag);
+    UIBlockInterface uiBlock = new UIBlockInterface() {
+      public void execute(NativeViewHierarchyManager nvhm) {
+        executeImpl(nvhm, null);
+      }
+      public void execute(UIManagerViewResolver uiBlockViewResolver) {
+        executeImpl(null, uiBlockViewResolver);
+      }
+      public void executeImpl(NativeViewHierarchyManager nvhm, UIBlockViewResolver uiBlockViewResolver) {
+        MapView view = (MapView) uiBlockViewResolver != null ? uiBlockViewResolver.resolveView(tag) : nvhm.resolveView(tag);
         if (view == null) {
           promise.reject("AirMapView not found");
           return;
@@ -179,20 +198,30 @@ public class MapModule extends ReactContextBaseJavaModule {
 
         promise.resolve(cameraJson);
       }
-    });
+    };
+
+    if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
+      UIManager uiManager = UIManagerHelper.getUIManager(context, UIManagerType.FABRIC);
+      ((FabricUIManager)uiManager).addUIBlock(uiBlock);
+    } else {
+      UIManagerModule uiManager = context.getNativeModule(UIManagerModule.class);
+      uiManager.addUIBlock(uiBlock);
+    }
   }
 
   @ReactMethod
   public void getAddressFromCoordinates(final int tag, final ReadableMap coordinate, final Promise promise) {
     final ReactApplicationContext context = getReactApplicationContext();
 
-    UIManagerModule uiManager = context.getNativeModule(UIManagerModule.class);
-    uiManager.addUIBlock(new UIBlock()
-    {
-      @Override
-      public void execute(NativeViewHierarchyManager nvhm)
-      {
-        MapView view = (MapView) nvhm.resolveView(tag);
+    UIBlockInterface uiBlock = new UIBlockInterface() {
+      public void execute(NativeViewHierarchyManager nvhm) {
+        executeImpl(nvhm, null);
+      }
+      public void execute(UIManagerViewResolver uiBlockViewResolver) {
+        executeImpl(null, uiBlockViewResolver);
+      }
+      public void executeImpl(NativeViewHierarchyManager nvhm, UIBlockViewResolver uiBlockViewResolver) {
+        MapView view = (MapView) uiBlockViewResolver != null ? uiBlockViewResolver.resolveView(tag) : nvhm.resolveView(tag);
         if (view == null) {
           promise.reject("AirMapView not found");
           return;
@@ -234,7 +263,15 @@ public class MapModule extends ReactContextBaseJavaModule {
           promise.reject("Can not get address location");
         }
       }
-    });
+    };
+
+    if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
+      UIManager uiManager = UIManagerHelper.getUIManager(context, UIManagerType.FABRIC);
+      ((FabricUIManager)uiManager).addUIBlock(uiBlock);
+    } else {
+      UIManagerModule uiManager = context.getNativeModule(UIManagerModule.class);
+      uiManager.addUIBlock(uiBlock);
+    }
   }
 
   @ReactMethod
@@ -247,13 +284,15 @@ public class MapModule extends ReactContextBaseJavaModule {
             coordinate.hasKey("longitude") ? coordinate.getDouble("longitude") : 0.0
     );
 
-    UIManagerModule uiManager = context.getNativeModule(UIManagerModule.class);
-    uiManager.addUIBlock(new UIBlock()
-    {
-      @Override
-      public void execute(NativeViewHierarchyManager nvhm)
-      {
-        MapView view = (MapView) nvhm.resolveView(tag);
+    UIBlockInterface uiBlock = new UIBlockInterface() {
+      public void execute(NativeViewHierarchyManager nvhm) {
+        executeImpl(nvhm, null);
+      }
+      public void execute(UIManagerViewResolver uiBlockViewResolver) {
+        executeImpl(null, uiBlockViewResolver);
+      }
+      public void executeImpl(NativeViewHierarchyManager nvhm, UIBlockViewResolver uiBlockViewResolver) {
+        MapView view = (MapView) uiBlockViewResolver != null ? uiBlockViewResolver.resolveView(tag) : nvhm.resolveView(tag);
         if (view == null) {
           promise.reject("AirMapView not found");
           return;
@@ -271,7 +310,15 @@ public class MapModule extends ReactContextBaseJavaModule {
 
         promise.resolve(ptJson);
       }
-    });
+    };
+
+    if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
+      UIManager uiManager = UIManagerHelper.getUIManager(context, UIManagerType.FABRIC);
+      ((FabricUIManager)uiManager).addUIBlock(uiBlock);
+    } else {
+      UIManagerModule uiManager = context.getNativeModule(UIManagerModule.class);
+      uiManager.addUIBlock(uiBlock);
+    }
   }
 
   @ReactMethod
@@ -284,13 +331,15 @@ public class MapModule extends ReactContextBaseJavaModule {
             point.hasKey("y") ? (int)(point.getDouble("y") * density) : 0
     );
 
-    UIManagerModule uiManager = context.getNativeModule(UIManagerModule.class);
-    uiManager.addUIBlock(new UIBlock()
-    {
-      @Override
-      public void execute(NativeViewHierarchyManager nvhm)
-      {
-        MapView view = (MapView) nvhm.resolveView(tag);
+    UIBlockInterface uiBlock = new UIBlockInterface() {
+      public void execute(NativeViewHierarchyManager nvhm) {
+        executeImpl(nvhm, null);
+      }
+      public void execute(UIManagerViewResolver uiBlockViewResolver) {
+        executeImpl(null, uiBlockViewResolver);
+      }
+      public void executeImpl(NativeViewHierarchyManager nvhm, UIBlockViewResolver uiBlockViewResolver) {
+        MapView view = (MapView) uiBlockViewResolver != null ? uiBlockViewResolver.resolveView(tag) : nvhm.resolveView(tag);
         if (view == null)
         {
           promise.reject("AirMapView not found");
@@ -310,20 +359,30 @@ public class MapModule extends ReactContextBaseJavaModule {
 
         promise.resolve(coordJson);
       }
-    });
+    };
+
+    if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
+      UIManager uiManager = UIManagerHelper.getUIManager(context, UIManagerType.FABRIC);
+      ((FabricUIManager)uiManager).addUIBlock(uiBlock);
+    } else {
+      UIManagerModule uiManager = context.getNativeModule(UIManagerModule.class);
+      uiManager.addUIBlock(uiBlock);
+    }
   }
 
   @ReactMethod
   public void getMapBoundaries(final int tag, final Promise promise) {
     final ReactApplicationContext context = getReactApplicationContext();
 
-    UIManagerModule uiManager = context.getNativeModule(UIManagerModule.class);
-    uiManager.addUIBlock(new UIBlock()
-    {
-      @Override
-      public void execute(NativeViewHierarchyManager nvhm)
-      {
-        MapView view = (MapView) nvhm.resolveView(tag);
+    UIBlockInterface uiBlock = new UIBlockInterface() {
+      public void execute(NativeViewHierarchyManager nvhm) {
+        executeImpl(nvhm, null);
+      }
+      public void execute(UIManagerViewResolver uiBlockViewResolver) {
+        executeImpl(null, uiBlockViewResolver);
+      }
+      public void executeImpl(NativeViewHierarchyManager nvhm, UIBlockViewResolver uiBlockViewResolver) {
+        MapView view = (MapView) uiBlockViewResolver != null ? uiBlockViewResolver.resolveView(tag) : nvhm.resolveView(tag);
         if (view == null) {
           promise.reject("AirMapView not found");
           return;
@@ -349,6 +408,16 @@ public class MapModule extends ReactContextBaseJavaModule {
 
         promise.resolve(coordinates);
       }
-    });
+    };
+
+    if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
+      UIManager uiManager = UIManagerHelper.getUIManager(context, UIManagerType.FABRIC);
+      ((FabricUIManager)uiManager).addUIBlock(uiBlock);
+    } else {
+      UIManagerModule uiManager = context.getNativeModule(UIManagerModule.class);
+      uiManager.addUIBlock(uiBlock);
+    }
   }
 }
+
+interface UIBlockInterface extends UIBlock, com.facebook.react.fabric.interop.UIBlock  {}


### PR DESCRIPTION
### Does any other open PR do the same thing?

No

### What issue is this PR fixing?

Following APIs will be broken in Bridgeless mode after https://github.com/react-native-maps/react-native-maps/pull/4985 adds support for Bridgeless in React Native 0.74 on Android :
- takeSnapshot()
- getCamera()
- getAddressFromCoordinates()
- pointForCoordinate()
- coordinateForPoint()
- getMapBoundaries()

Since these [depend](https://github.com/react-native-maps/react-native-maps/blob/master/android/src/main/java/com/rnmaps/maps/MapModule.java#L93-L94) on `context.getNativeModule(UIManagerModule.class)`:

which returns null in Bridgeless

https://github.com/facebook/react-native/blob/main/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java#L600-L606

### How did you test this PR?

Test `takeSnapshot()` functionality for Android in Bridgeless
