### PR TITLE
Fixed #4512

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
-    "target": "esnext"
+    "target": "esnext",
+    "useDefineForClassFields": false
   }
 }


### PR DESCRIPTION
As of ES2022 (or project with tsconfig.json target: ESNext), class fields are now valid syntax, which is a breaking change when using ESNext (Expo default) and causes issues where parent class methods are overwritten with undefined. It's a broad JS library ecosystem issue and every maintainer should make a decision. Explanation: react-native-maps/react-native-maps#4512 (comment)

<!--
PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.

**What happens if you SKIP this step?**

Your pull request will NOT be evaluated!

PLEASE NOTE THAT PRs WITHOUT THE TEMPLATE IN PLACE WILL BE CLOSED RIGHT FROM THE START.

Thanks for helping us help you!
-->

### Does any other open PR do the same thing?

Not exactly, however the issue is reported several times and at one point claimed fixed. It was not fixed properly. Babel does not seem to be the culprit. Babel transpiled TypeScript code but the output of Typescript is unexpected because of recent ECMAScript changes. Thus, it's a backwards-incompatible change that other PRs does not seem to consider.

### What issue is this PR fixing?

https://github.com/react-native-maps/react-native-maps/issues/4512

### How did you test this PR?

iOS + Android are affected. **No tests done**, please review approach before further work is done. Feel free to dismiss PR but you should be aware that transpiled code may not be doing what you want due to "recent" changes.

<!--
Thanks for your contribution :)
-->
