### PR TITLE
fix(iOS): ensure onPress(Marker) returns nativeEvent.position #4996

### DIFF
--- a/ios/AirMaps/AIRMapMarker.m
+++ b/ios/AirMaps/AIRMapMarker.m
@@ -264,12 +264,17 @@ NSInteger const AIR_CALLOUT_OPEN_ZINDEX_BASELINE = 999;
     }
 
     // the actual marker got clicked
+    CGPoint touchPointReal = [recognizer locationInView:self.calloutView];
     id event = @{
                  @"action": @"marker-press",
                  @"id": marker.identifier ?: @"unknown",
                  @"coordinate": @{
                          @"latitude": @(marker.coordinate.latitude),
                          @"longitude": @(marker.coordinate.longitude)
+                         },
+                 @"point": @{
+                         @"x": @(touchPointReal.x),
+                         @"y": @(touchPointReal.y),
                          }
                  };
 


### PR DESCRIPTION
### Does any other open PR do the same thing?

No.

### What issue is this PR fixing?

#4996 

### How did you test this PR?

<!--
Please let us know how you have verified that your changes work.

Ideally, your PR should contain a step-by-step test plan, so that reviewers can easily verify your changes.

Your PR will have much better chances of being merged if it is straightforward to verify.

Some questions you might want to think about:

- Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any?
- Did you test this on a real device, or in a simulator?
- Are there any platforms you were not able to test?
-->

I have tested it on iPhone 15 Pro simulator(iOS 17.5) and iPhone 14 Pro(iOS 17.5.1).
(The issue occurs only iOS)

### Steps:
1. Specify an  onPress for a Marker on a iOS device.
2. Tap a marker and see the event.nativeEvent returns position as well.

In addition, this is a repository AirMapMarker.m file patched with patch-packager: 
You can also check it. [repro-on-marker-press](https://github.com/abdullahbayram/repro-on-marker-press)

