### PR TITLE
feat(ios): allow use of light compass theme with satellite/hybrid map…

### DIFF
--- a/ios/AirMaps/AIRMap.m
+++ b/ios/AirMaps/AIRMap.m
@@ -707,15 +707,6 @@ const NSInteger AIRMapMaxZoomLevel = 20;
 - (void)layoutSubviews {
     [super layoutSubviews];
     [self cacheViewIfNeeded];
-    NSUInteger index = [[self subviews] indexOfObjectPassingTest:^BOOL(__kindof UIView * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
-        NSString *str = NSStringFromClass([obj class]);
-        return [str containsString:@"MKCompassView"];
-    }];
-    if (index != NSNotFound) {
-        UIView* compassButton;
-        compassButton = [self.subviews objectAtIndex:index];
-        compassButton.frame = CGRectMake(compassButton.frame.origin.x + _compassOffset.x, compassButton.frame.origin.y + _compassOffset.y, compassButton.frame.size.width, compassButton.frame.size.height);
-    }
 
     if (self.overlayCompassButton == nil) {
         for (UIView *subview in self.subviews) {

--- a/ios/AirMaps/AIRMap.m
+++ b/ios/AirMaps/AIRMap.m
@@ -38,6 +38,8 @@ const NSInteger AIRMapMaxZoomLevel = 20;
 @property (nonatomic, strong) UIActivityIndicatorView *activityIndicatorView;
 @property (nonatomic, assign) NSNumber *shouldZoomEnabled;
 @property (nonatomic, assign) NSNumber *shouldScrollEnabled;
+@property (nonatomic, strong) MKCompassButton *defaultCompassButton;
+@property (nonatomic, strong) MKCompassButton *overlayCompassButton;
 
 - (void)updateScrollEnabled;
 - (void)updateZoomEnabled;
@@ -508,6 +510,9 @@ const NSInteger AIRMapMaxZoomLevel = 20;
 // and check if their selector is available before calling super method.
 
 - (void)setShowsCompass:(BOOL)showsCompass {
+    if (self.overlayCompassButton != nil) {
+        self.overlayCompassButton.compassVisibility = showsCompass ? MKFeatureVisibilityAdaptive : MKFeatureVisibilityHidden;
+    }
     if ([MKMapView instancesRespondToSelector:@selector(setShowsCompass:)]) {
         [super setShowsCompass:showsCompass];
     }
@@ -711,6 +716,29 @@ const NSInteger AIRMapMaxZoomLevel = 20;
         compassButton = [self.subviews objectAtIndex:index];
         compassButton.frame = CGRectMake(compassButton.frame.origin.x + _compassOffset.x, compassButton.frame.origin.y + _compassOffset.y, compassButton.frame.size.width, compassButton.frame.size.height);
     }
+
+    if (self.overlayCompassButton == nil) {
+        for (UIView *subview in self.subviews) {
+            if (![NSStringFromClass(subview.class) isEqualToString:@"MKPassThroughStackView"]) continue;
+            self.overlayCompassButton = [MKCompassButton compassButtonWithMapView:self];
+            [subview addSubview:self.overlayCompassButton];
+            self.overlayCompassButton.frame = CGRectMake(self.overlayCompassButton.frame.origin.x + _compassOffset.x, self.overlayCompassButton.frame.origin.y + _compassOffset.y, self.overlayCompassButton.frame.size.width, self.overlayCompassButton.frame.size.height);
+            break;
+        }
+    }
+    
+    if (self.defaultCompassButton == nil) {
+        for (UIView *subview in self.subviews) {
+            if (![NSStringFromClass(subview.class) isEqualToString:@"MKPassThroughStackView"]) continue;
+            for (UIView *subview2 in subview.subviews) {
+                if (![NSStringFromClass(subview2.class) isEqualToString:@"MKCompassView"]) continue;
+                self.defaultCompassButton = subview2;
+                self.defaultCompassButton.hidden = YES;
+            }
+            break;
+        }
+    }
+    
 }
 
 // based on https://medium.com/@dmytrobabych/getting-actual-rotation-and-zoom-level-for-mapkit-mkmapview-e7f03f430aa9


### PR DESCRIPTION
### Does any other open PR do the same thing?

No

### What issue is this PR fixing?
 
- Implements [this feature request](https://github.com/react-native-maps/react-native-maps/discussions/5098#discussion-6839158)
- Also fixes #5097 

### How did you test this PR?

With an iOS simulator, used several combinations of the userInterfaceStyle, MapType and compassOffset props on a MapView, and confirmed that the compass appearance and position updated accordingly.

This PR only affects the compass from Apple Maps.
