### PR TITLE
Implement dash options for geojson polygon

### DIFF
--- a/src/Geojson.tsx
+++ b/src/Geojson.tsx
@@ -261,6 +261,11 @@ const Geojson = (props: GeojsonProps) => {
             strokeColor={lineStrokeColor}
             fillColor={polygonFillColor}
             strokeWidth={lineStrokeWidth}
+            lineDashPhase={lineDashPhase}
+            lineDashPattern={lineDashPattern}
+            lineCap={lineCap}
+            lineJoin={lineJoin}
+            miterLimit={miterLimit}
             tappable={tappable}
             onPress={() => onPress && onPress(overlay)}
             zIndex={zIndex}


### PR DESCRIPTION
### Does any other open PR do the same thing?

No

### What issue is this PR fixing?

Add missing props for polygon in the Geojson component. So I provided these props (lineDashPhase, lineDashPattern, lineCap, lineJoin and miterLimit) so an Geojson component with a polygon can also render a dashed line.

### How did you test this PR?

I have tested the change on iOS using an iPhone and in the simulator. For Android, this will not work because this is not implemented yet in Android.
