### PR TITLE
feat(android): add dash pattern for android (#5115)

### DIFF
--- a/android/src/main/java/com/rnmaps/maps/MapPolygon.java
+++ b/android/src/main/java/com/rnmaps/maps/MapPolygon.java
@@ -4,7 +4,10 @@ import android.content.Context;
 
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
+import com.google.android.gms.maps.model.Dash;
+import com.google.android.gms.maps.model.Gap;
 import com.google.android.gms.maps.model.LatLng;
+import com.google.android.gms.maps.model.PatternItem;
 import com.google.android.gms.maps.model.Polygon;
 import com.google.android.gms.maps.model.PolygonOptions;
 import com.google.maps.android.collections.PolygonManager;
@@ -25,6 +28,8 @@ public class MapPolygon extends MapFeature {
   private boolean geodesic;
   private boolean tappable;
   private float zIndex;
+  private ReadableArray patternValues;
+  private List<PatternItem> pattern;
 
   public MapPolygon(Context context) {
     super(context);
@@ -117,6 +122,32 @@ public class MapPolygon extends MapFeature {
     }
   }
 
+  public void setLineDashPattern(ReadableArray patternValues) {
+    this.patternValues = patternValues;
+    this.applyPattern();
+  }
+
+  private void applyPattern() {
+    if(patternValues == null) {
+      return;
+    }
+    this.pattern = new ArrayList<>(patternValues.size());
+    for (int i = 0; i < patternValues.size(); i++) {
+      float patternValue = (float) patternValues.getDouble(i);
+      boolean isGap = i % 2 != 0;
+      if(isGap) {
+        this.pattern.add(new Gap(patternValue));
+      }else {
+        PatternItem patternItem;
+        patternItem = new Dash(patternValue);
+        this.pattern.add(patternItem);
+      }
+    }
+    if(polygon != null) {
+      polygon.setStrokePattern(this.pattern);
+    }
+  }
+
   public PolygonOptions getPolygonOptions() {
     if (polygonOptions == null) {
       polygonOptions = createPolygonOptions();
@@ -132,6 +163,7 @@ public class MapPolygon extends MapFeature {
     options.strokeWidth(strokeWidth);
     options.geodesic(geodesic);
     options.zIndex(zIndex);
+    options.strokePattern(this.pattern);
 
     if (this.holes != null) {
       for (int i = 0; i < holes.size(); i++) {

--- a/android/src/main/java/com/rnmaps/maps/MapPolygonManager.java
+++ b/android/src/main/java/com/rnmaps/maps/MapPolygonManager.java
@@ -78,6 +78,11 @@ public class MapPolygonManager extends ViewGroupManager<MapPolygon> {
     view.setZIndex(zIndex);
   }
 
+  @ReactProp(name = "lineDashPattern")
+  public void setLineDashPattern(MapPolygon view, ReadableArray patternValues) {
+      view.setLineDashPattern(patternValues);
+  }
+
   @Override
   @Nullable
   public Map getExportedCustomDirectEventTypeConstants() {

--- a/src/Geojson.tsx
+++ b/src/Geojson.tsx
@@ -73,7 +73,9 @@ export type GeojsonProps = {
    * @platform iOS: Supported
    * @platform Android: Supported
    */
-  lineDashPattern?: PolylineProps['lineDashPattern'];
+  lineDashPattern?:
+    | PolygonProps['lineDashPattern']
+    | PolylineProps['lineDashPattern'];
 
   /**
    * The offset (in points) at which to start drawing the dash pattern.

--- a/src/MapPolygon.tsx
+++ b/src/MapPolygon.tsx
@@ -64,7 +64,7 @@ export type MapPolygonProps = ViewProps & {
    * followed by the first gap length, followed by the second line segment length, and so on.
    *
    * @platform iOS: Apple Maps only
-   * @platform Android: Not supported
+   * @platform Android: Supported
    */
   lineDashPattern?: number[];
 


### PR DESCRIPTION
### Does any other open PR do the same thing?

No

### What issue is this PR fixing?

As mentioned in https://github.com/react-native-maps/react-native-maps/pull/5115, Android still does not support dashed lines. With this update, you can now use the lineDashPattern prop with both Polygon and Geojson components.

### How did you test this PR?

I have tested the change on Android using an Samsung phone and in the emulator. 
