### PR TITLE
fix (ios): Add check for nil values before adding to subviews in iOS Google Maps

### DIFF
--- a/ios/AirGoogleMaps/AIRGoogleMap.m
+++ b/ios/AirGoogleMaps/AIRGoogleMap.m
@@ -188,7 +188,9 @@ id regionAsJSON(MKCoordinateRegion region) {
       [self insertReactSubview:(UIView *)childSubviews[i] atIndex:atIndex];
     }
   }
-  [_reactSubviews insertObject:(UIView *)subview atIndex:(NSUInteger) atIndex];
+  if (subview != nil) {
+    [_reactSubviews insertObject:(UIView *)subview atIndex:(NSUInteger) atIndex];
+  }
 }
 #pragma clang diagnostic pop
 
@@ -957,15 +959,16 @@ id regionAsJSON(MKCoordinateRegion region) {
     marker.layer.position = CGPointZero;
 
     [self insertReactSubview:(UIView *) marker atIndex:index];
-
-    [markers addObject:@{@"id": marker.identifier,
-                         @"title": marker.title,
-                         @"description": marker.subtitle,
-                         @"coordinate": @{
-                             @"latitude": @(location.latitude),
-                             @"longitude": @(location.longitude)
-                             }
-                         }];
+    if (marker.identifier != nil && marker.title != nil && marker.subtitle != nil) {
+      [markers addObject:@{@"id": marker.identifier,
+                          @"title": marker.title,
+                          @"description": marker.subtitle,
+                          @"coordinate": @{
+                              @"latitude": @(location.latitude),
+                              @"longitude": @(location.longitude)
+                              }
+                          }];
+    }
 
     index++;
   }

--- a/ios/AirGoogleMaps/AIRGoogleMap.m
+++ b/ios/AirGoogleMaps/AIRGoogleMap.m
@@ -189,7 +189,8 @@ id regionAsJSON(MKCoordinateRegion region) {
     }
   }
   if (subview != nil) {
-    [_reactSubviews insertObject:(UIView *)subview atIndex:(NSUInteger) atIndex];
+    NSUInteger safeIndex = MIN(atIndex, _reactSubviews.count);
+    [_reactSubviews insertObject:(UIView *)subview atIndex:safeIndex];
   }
 }
 #pragma clang diagnostic pop


### PR DESCRIPTION
Adds `nil` checks before pushing new subviews in iOS - Fixes #5217 

### Does any other open PR do the same thing?

<!--
**Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**

If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)
 -->

N/A - No prior PR raised

### What issue is this PR fixing?

#5217 - *** -[__NSArrayM insertObject:atIndex:]: object cannot be nil issue

### How did you test this PR?

<!--
Please let us know how you have verified that your changes work.

Ideally, your PR should contain a step-by-step test plan, so that reviewers can easily verify your changes.

Your PR will have much better chances of being merged if it is straightforward to verify.

Some questions you might want to think about:

- Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any?
- Did you test this on a real device, or in a simulator?
- Are there any platforms you were not able to test?
-->

Tested in iOS Real Device & Simulator - Expo 52/RN 0.76.2 (New Architecture Enabled) (Google Maps)

<!--
Thanks for your contribution :)
-->
