### PR TITLE
fix: subview nil check before inserting on Apple Maps

### DIFF
--- a/ios/AirMaps/AIRMap.m
+++ b/ios/AirMaps/AIRMap.m
@@ -135,7 +135,11 @@ const NSInteger AIRMapMaxZoomLevel = 20;
             [self insertReactSubview:(UIView *)childSubviews[i] atIndex:atIndex];
         }
     }
-    [_reactSubviews insertObject:(UIView *)subview atIndex:(NSUInteger) atIndex];
+    
+    if (subview != nil) {
+        NSUInteger safeIndex = MIN(atIndex, _reactSubviews.count);
+        [_reactSubviews insertObject:(UIView *)subview atIndex:safeIndex];
+    }
 }
 #pragma clang diagnostic pop
 


### PR DESCRIPTION
<!--
PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.

**What happens if you SKIP this step?**

Your pull request will NOT be evaluated!

PLEASE NOTE THAT PRs WITHOUT THE TEMPLATE IN PLACE WILL BE CLOSED RIGHT FROM THE START.

Thanks for helping us help you!
-->

### Does any other open PR do the same thing?

<!--
**Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**

If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)
 -->

Yes it does #5226 but limited to Google Maps iOS not for Apple Maps.

### What issue is this PR fixing?

This PR includes fix for #5217 but for Apple Maps.

### How did you test this PR?

<!--
Please let us know how you have verified that your changes work.

Ideally, your PR should contain a step-by-step test plan, so that reviewers can easily verify your changes.

Your PR will have much better chances of being merged if it is straightforward to verify.

Some questions you might want to think about:

- Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any?
- Did you test this on a real device, or in a simulator?
- Are there any platforms you were not able to test?
-->

Tested locally on both Real Device and Simulator with iOS 18.1 and Expo SDK 52 (New Architecture enabled)

<!--
Thanks for your contribution :)
-->
