### PR TITLE
fix: simplified generated podspec to pass lint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 # Xcode
 #
 build/
+buildoutput.txt
 *.pbxuser
 !default.pbxuser
 *.mode1v3

--- a/react-native-maps-generated.podspec
+++ b/react-native-maps-generated.podspec
@@ -1,16 +1,15 @@
 # react-native-maps-generated-simple.podspec
 Pod::Spec.new do |s|
   s.name = "react-native-maps-generated"
-  s.version = "1.22.2"
+  s.version = "1.22.3"
   s.summary = "React Native Mapview component for iOS + Android"
   s.authors = { "Salah Ghanim" => "salah.ghanim@gmail.com" }
   s.homepage = "https://github.com/react-native-maps/react-native-maps"
-  s.license = "MIT"
+  s.license = { :type => 'MIT', :url => 'https://opensource.org/licenses/MIT' }
   s.platform = :ios, "15.1"
-  s.source = { :git => "https://github.com/react-native-maps/react-native-maps.git", :tag => "v1.22.2" }
+  s.source = { :git => "https://github.com/react-native-maps/react-native-maps.git", :tag => "v1.22.3" }
   s.source_files = "ios/generated/**/*.{h,m,mm,swift}"
   s.module_map = 'ios/generated/module.modulemap'
   s.public_header_files = "ios/generated/**/*.h"
   s.module_name = 'ReactNativeMapsGenerated'
-  s.dependency 'React-Core'
 end


### PR DESCRIPTION


### Does any other open PR do the same thing?

No


### What issue is this PR fixing?

having the generated pod visible via cocoapods trunk

### How did you test this PR?
not yet possible

