### PR TITLE
docs: update min iOS version in installation guide

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -78,12 +78,12 @@ If you want to enable Google Maps on iOS, obtain the Google API key and edit you
 
 The `[GMSServices provideAPIKey]` should be the **first call** of the method.
 
-Google Maps SDK for iOS requires iOS 14, so make sure that your deployment target is >= 4 in your iOS project settings.
+Google Maps SDK for iOS requires iOS 15, so make sure that your deployment target is >= 15 in your iOS project settings.
 
-Also make sure that your Podfile deployment target is set to >= 14 at the top of your Podfile, eg:
+Also make sure that your Podfile deployment target is set to >= 15 at the top of your Podfile, eg:
 
 ```ruby
-platform :ios, '14'
+platform :ios, '15'
 ```
 
 Add the following to your Podfile above the `use_native_modules!` function and run `pod install` in the ios folder:


### PR DESCRIPTION
### Does any other open PR do the same thing?

No

### What issue is this PR fixing?

This PR updates the minimum iOS version requirement in the installation guide based in [latest major release](https://github.com/react-native-maps/react-native-maps/releases/tag/v1.21.0)