### PR TITLE
feat(iOS/Android): Improve KML support

### DIFF
--- a/android/src/main/java/com/facebook/react/viewmanagers/RNMapsMapViewManagerDelegate.java
+++ b/android/src/main/java/com/facebook/react/viewmanagers/RNMapsMapViewManagerDelegate.java
@@ -47,7 +47,7 @@ public class RNMapsMapViewManagerDelegate<T extends View, U extends BaseViewMana
         mViewManager.setInitialRegion(view, (ReadableMap) value);
         break;
       case "kmlSrc":
-        mViewManager.setKmlSrc(view, value == null ? null : (String) value);
+        mViewManager.setKmlSrc(view, (ReadableArray) value);
         break;
       case "legalLabelInsets":
         mViewManager.setLegalLabelInsets(view, (ReadableMap) value);

--- a/android/src/main/java/com/facebook/react/viewmanagers/RNMapsMapViewManagerInterface.java
+++ b/android/src/main/java/com/facebook/react/viewmanagers/RNMapsMapViewManagerInterface.java
@@ -11,6 +11,7 @@ package com.facebook.react.viewmanagers;
 
 import android.view.View;
 import androidx.annotation.Nullable;
+import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 
 public interface RNMapsMapViewManagerInterface<T extends View> {
@@ -21,7 +22,7 @@ public interface RNMapsMapViewManagerInterface<T extends View> {
   void setPoiClickEnabled(T view, boolean value);
   void setInitialCamera(T view, @Nullable ReadableMap value);
   void setInitialRegion(T view, @Nullable ReadableMap value);
-  void setKmlSrc(T view, @Nullable String value);
+  void setKmlSrc(T view, @Nullable ReadableArray value);
   void setLegalLabelInsets(T view, @Nullable ReadableMap value);
   void setLiteMode(T view, boolean value);
   void setGoogleMapId(T view, @Nullable String value);

--- a/android/src/main/java/com/rnmaps/fabric/MapViewManager.java
+++ b/android/src/main/java/com/rnmaps/fabric/MapViewManager.java
@@ -14,6 +14,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
@@ -34,11 +35,12 @@ import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.LatLngBounds;
 import com.google.android.gms.maps.model.MapColorScheme;
 import com.rnmaps.maps.MapMarker;
-import com.rnmaps.maps.MapOverlay;
 import com.rnmaps.maps.MapView;
 import com.rnmaps.maps.SizeReportingShadowNode;
 
+import java.util.ArrayList;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @ReactModule(name = MapViewManager.REACT_CLASS)
 public class MapViewManager extends ViewGroupManager<MapView> implements RNMapsMapViewManagerInterface<MapView> {
@@ -239,8 +241,18 @@ public class MapViewManager extends ViewGroupManager<MapView> implements RNMapsM
     }
 
     @Override
-    public void setKmlSrc(MapView view, @Nullable String value) {
-        view.setKmlSrc(value);
+    public void setKmlSrc(MapView view, @Nullable ReadableArray kmlUrls) {
+        if (kmlUrls != null && kmlUrls.size() > 0) {
+            ArrayList<String> kmlUrlList = kmlUrls.toArrayList()
+                    .stream()
+                    .filter(obj -> obj instanceof String)
+                    .map(obj -> (String) obj)
+                    .collect(Collectors.toCollection(ArrayList::new));
+
+            view.setKmlSrcList(kmlUrlList);
+        } else {
+            view.clearKmlLayers();
+        }
     }
 
     @Override

--- a/android/src/main/java/com/rnmaps/maps/MapManager.java
+++ b/android/src/main/java/com/rnmaps/maps/MapManager.java
@@ -28,7 +28,9 @@ import com.google.android.gms.maps.model.CameraPosition;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.LatLngBounds;
 
+import java.util.ArrayList;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class MapManager extends ViewGroupManager<MapView> {
 
@@ -329,9 +331,17 @@ public class MapManager extends ViewGroupManager<MapView> {
     }
 
     @ReactProp(name = "kmlSrc")
-    public void setKmlSrc(MapView view, String kmlUrl) {
-        if (kmlUrl != null) {
-            view.setKmlSrc(kmlUrl);
+    public void setKmlSrc(MapView view, @Nullable ReadableArray kmlUrls) {
+        if (kmlUrls != null && kmlUrls.size() > 0) {
+            ArrayList<String> kmlUrlList = kmlUrls.toArrayList()
+                    .stream()
+                    .filter(obj -> obj instanceof String)
+                    .map(obj -> (String) obj)
+                    .collect(Collectors.toCollection(ArrayList::new));
+
+            view.setKmlSrcList(kmlUrlList);
+        } else {
+            view.clearKmlLayers();
         }
     }
 

--- a/android/src/main/java/com/rnmaps/maps/MapView.java
+++ b/android/src/main/java/com/rnmaps/maps/MapView.java
@@ -80,9 +80,11 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
 import com.rnmaps.fabric.event.*;
@@ -131,6 +133,7 @@ public class MapView extends com.google.android.gms.maps.MapView implements Goog
     private LatLngBounds cameraLastIdleBounds;
     private int cameraMoveReason = 0;
     private MapMarker selectedMarker;
+    private Map<String, KmlLayer> kmlLayers = new HashMap<>();
 
     private static final String[] PERMISSIONS = new String[]{
             "android.permission.ACCESS_FINE_LOCATION", "android.permission.ACCESS_COARSE_LOCATION"};
@@ -162,7 +165,7 @@ public class MapView extends com.google.android.gms.maps.MapView implements Goog
     private Boolean showIndoors;
     private Boolean scrollEnabled;
     private Boolean scrollDuringRotateOrZoomEnabled;
-    private String kmlSrc = null;
+    private @Nullable ArrayList<String> kmlSrcList;
 
     private static boolean contextHasBug(Context context) {
         return context == null ||
@@ -601,9 +604,9 @@ public class MapView extends com.google.android.gms.maps.MapView implements Goog
 
 
         isMapReady = true;
-        if (kmlSrc != null) {
-            setKmlSrc(kmlSrc);
-            kmlSrc = null;
+        if (kmlSrcList != null) {
+            setKmlSrcList(this.kmlSrcList);
+            this.kmlSrcList = null;
         }
     }
 
@@ -1646,101 +1649,63 @@ public class MapView extends com.google.android.gms.maps.MapView implements Goog
 
     }
 
-    public void setKmlSrc(String kmlSrc) {
-        if (isMapReady) {
-            try {
-                InputStream kmlStream = new FileUtil(context).execute(kmlSrc).get();
-
-                if (kmlStream == null) {
-                    return;
-                }
-
-                KmlLayer kmlLayer = new KmlLayer(map, kmlStream, context, markerManager, polygonManager, polylineManager, groundOverlayManager, null);
-
-                kmlLayer.addLayerToMap();
-
-                WritableMap pointers = new WritableNativeMap();
-                WritableArray markers = new WritableNativeArray();
-
-                if (kmlLayer.getContainers() == null) {
-                    dispatchEvent(pointers, OnKmlReadyEvent::new);
-                    return;
-                }
-
-                //Retrieve a nested container within the first container
-                KmlContainer container = kmlLayer.getContainers().iterator().next();
-                if (container == null || container.getContainers() == null) {
-                    dispatchEvent(pointers, OnKmlReadyEvent::new);
-                    return;
-                }
-
-
-                if (container.getContainers().iterator().hasNext()) {
-                    container = container.getContainers().iterator().next();
-                }
-
-                int index = 0;
-                for (KmlPlacemark placemark : container.getPlacemarks()) {
-                    MarkerOptions options = new MarkerOptions();
-
-                    if (placemark.getInlineStyle() != null) {
-                        options = placemark.getMarkerOptions();
-                    } else {
-                        options.icon(BitmapDescriptorFactory.defaultMarker());
-                    }
-
-                    LatLng latLng = ((LatLng) placemark.getGeometry().getGeometryObject());
-                    String title = "";
-                    String snippet = "";
-
-                    if (placemark.hasProperty("name")) {
-                        title = placemark.getProperty("name");
-                    }
-
-                    if (placemark.hasProperty("description")) {
-                        snippet = placemark.getProperty("description");
-                    }
-
-                    options.position(latLng);
-                    options.title(title);
-                    options.snippet(snippet);
-                    // FIXME: get markerManager from somewhere
-        /*
-        MapMarker marker = new MapMarker(context, options, this.manager.getMarkerManager());
-
-        if (placemark.getInlineStyle() != null
-            && placemark.getInlineStyle().getIconUrl() != null) {
-          marker.setImage(placemark.getInlineStyle().getIconUrl());
-        } else if (container.getStyle(placemark.getStyleId()) != null) {
-          KmlStyle style = container.getStyle(placemark.getStyleId());
-          marker.setImage(style.getIconUrl());
+    public void clearKmlLayers() {
+        if (!this.kmlLayers.isEmpty()) {
+            for (Map.Entry<String, KmlLayer> entry : this.kmlLayers.entrySet()) {
+                entry.getValue().removeLayerFromMap();
+            }
+            this.kmlLayers.clear();
         }
+    }
 
-        String identifier = title + " - " + index;
-
-        marker.setIdentifier(identifier);
-
-        addFeature(marker, index++);
-
-
-        WritableMap loadedMarker = makeClickEventData(latLng);
-        loadedMarker.putString("id", identifier);
-        loadedMarker.putString("title", title);
-        loadedMarker.putString("description", snippet);
-
-        markers.pushMap(loadedMarker);
-         */
+    public void setKmlSrcList(ArrayList<String> kmlSrcList) {
+        if (this.isMapReady) {
+            kmlSrcList.forEach(kmlUrl -> {
+                if (this.kmlLayers.get(kmlUrl) == null) {
+                    addKmlSrc(kmlUrl);
                 }
+            });
 
-                pointers.putArray("markers", markers);
+            Set<String> currentKmlUrls = new HashSet<>(this.kmlLayers.keySet());
+            currentKmlUrls.forEach(kmlUrl -> {
+                if (!kmlSrcList.contains(kmlUrl)) {
+                    removeKmlSrc(kmlUrl);
+                }
+            });
+
+            if (!kmlSrcList.isEmpty() || !this.kmlLayers.isEmpty()) {
                 dispatchEvent(new WritableNativeMap(), OnKmlReadyEvent::new);
-
-            } catch (XmlPullParserException | IOException | InterruptedException |
-                     ExecutionException e) {
-                e.printStackTrace();
             }
         } else {
-            this.kmlSrc = kmlSrc;
+            this.kmlSrcList = kmlSrcList;
+        }
+    }
+
+
+    private void removeKmlSrc(String kmlSrc) {
+        @Nullable KmlLayer layer = this.kmlLayers.get(kmlSrc);
+        if (layer != null) {
+            layer.removeLayerFromMap();
+        }
+        this.kmlLayers.remove(kmlSrc);
+    }
+
+    private void addKmlSrc(String kmlSrc) {
+        try {
+            InputStream kmlStream = new FileUtil(context).execute(kmlSrc).get();
+
+            if (kmlStream == null) {
+                return;
+            }
+
+            KmlLayer kmlLayer = new KmlLayer(map, kmlStream, context, markerManager, polygonManager, polylineManager, groundOverlayManager, null);
+            kmlLayer.addLayerToMap();
+
+            this.kmlLayers.put(kmlSrc, kmlLayer);
+
+        } catch (XmlPullParserException | IOException | InterruptedException |
+                 ExecutionException e) {
+            e.printStackTrace();
         }
     }
 

--- a/android/src/main/jni/react/renderer/components/RNMapsSpecs/Props.h
+++ b/android/src/main/jni/react/renderer/components/RNMapsSpecs/Props.h
@@ -368,7 +368,7 @@ class RNMapsGoogleMapViewProps final : public ViewProps {
   RNMapsGoogleMapViewCameraStruct camera{};
   RNMapsGoogleMapViewInitialCameraStruct initialCamera{};
   RNMapsGoogleMapViewInitialRegionStruct initialRegion{};
-  std::string kmlSrc{};
+  std::vector<std::string> kmlSrc{};
   std::string googleMapId{};
   SharedColor loadingBackgroundColor{};
   RNMapsGoogleMapViewMapPaddingStruct mapPadding{};
@@ -886,7 +886,7 @@ class RNMapsMapViewProps final : public ViewProps {
   bool poiClickEnabled{false};
   RNMapsMapViewInitialCameraStruct initialCamera{};
   RNMapsMapViewInitialRegionStruct initialRegion{};
-  std::string kmlSrc{};
+  std::vector<std::string> kmlSrc{};
   RNMapsMapViewLegalLabelInsetsStruct legalLabelInsets{};
   bool liteMode{false};
   std::string googleMapId{};

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1337,6 +1337,9 @@ PODS:
     - React-jsiexecutor
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
+  - react-native-maps (0.0.0):
+    - react-native-maps/Maps (= 0.0.0)
+    - SSZipArchive
   - react-native-maps/Generated (0.0.0):
     - DoubleConversion
     - glog
@@ -1360,6 +1363,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
+    - SSZipArchive
     - Yoga
   - react-native-maps/Google (0.0.0):
     - DoubleConversion
@@ -1388,6 +1392,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
+    - SSZipArchive
     - Yoga
   - react-native-maps/Maps (0.0.0):
     - DoubleConversion
@@ -1413,6 +1418,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
+    - SSZipArchive
     - Yoga
   - React-NativeModulesApple (0.79.1):
     - glog
@@ -1737,6 +1743,7 @@ PODS:
     - React-perflogger (= 0.79.1)
     - React-utils (= 0.79.1)
   - SocketRocket (0.7.1)
+  - SSZipArchive (2.4.3)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -1780,6 +1787,7 @@ DEPENDENCIES:
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
   - React-Mapbuffer (from `../node_modules/react-native/ReactCommon`)
   - React-microtasksnativemodule (from `../node_modules/react-native/ReactCommon/react/nativemodule/microtasks`)
+  - react-native-maps (from `../..`)
   - react-native-maps/Google (from `../..`)
   - React-NativeModulesApple (from `../node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios`)
   - React-oscompat (from `../node_modules/react-native/ReactCommon/oscompat`)
@@ -1819,6 +1827,7 @@ SPEC REPOS:
     - Google-Maps-iOS-Utils
     - GoogleMaps
     - SocketRocket
+    - SSZipArchive
 
 EXTERNAL SOURCES:
   boost:
@@ -1975,72 +1984,73 @@ SPEC CHECKSUMS:
   Google-Maps-iOS-Utils: 0a484b05ed21d88c9f9ebbacb007956edd508a96
   GoogleMaps: b58e9627004f47043897eeae830c3ef023678f3b
   hermes-engine: c32f2e405098bc1ebe30630a051ddce6f21d3c2e
-  RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
+  RCT-Folly: 36fe2295e44b10d831836cc0d1daec5f8abcf809
   RCTDeprecation: 0ada4fb1e5c5637bff940dc40b94e2d3bf96b0ab
   RCTRequired: 76ca80ff10acb3834ed0dacba9645645009578a2
   RCTTypeSafety: 01b27f48153eb2d222c0ad4737fe291e9549946a
   React: 1195b4ef93124e47a492ec43d8aceb770618ceb0
   React-callinvoker: f8d4f94d6d5da7230803fa4fce2da27c9c843478
-  React-Core: b5a77faf86a0da01bce62f0b9bd1e3e77020090d
-  React-CoreModules: 597e6f05526da8c133f726961f333d62becd97bf
-  React-cxxreact: 25b20d44eaf2ef8774c7fefa3517cbfa18b16d7b
+  React-Core: 86bb10ed8cf63fe4546350754c85760eb206cb3f
+  React-CoreModules: a82c1b604691358c7ee80458a14d2791cdd56f20
+  React-cxxreact: b673ea0a99d910a55e316a4b198a59a6d873bd5c
   React-debug: 29bd770acc5506c22bde627adcd0b25a4c9db5bb
-  React-defaultsnativemodule: 4e6c6c9e6be81e74ef5c0c1065e7bb79b5d405a3
-  React-domnativemodule: 4fb2bf30d7687667caad907d77849a3c0a34d62b
-  React-Fabric: 24f23b7c2809bf3eb0eac360e76be359fc792b07
-  React-FabricComponents: b782f3c667008fdb12856b30ad19c04055930751
-  React-FabricImage: a58cb067f8a25f66a52e61484f790569b12bed71
+  React-defaultsnativemodule: 259fa69eab644bc661ce88336732769605f7fd02
+  React-domnativemodule: 5fced7465a3e322408da13d29d8643db9cc36b21
+  React-Fabric: 169061b03776c771743f2d0572082cb5a4a8610b
+  React-FabricComponents: 1d0a00e69b45174c53826fd501cc3ade250e47d8
+  React-FabricImage: 298580ce571206873837a44f447cd1269f5745ff
   React-featureflags: f7aac85238436b9c5c50056859ff234542fa535a
-  React-featureflagsnativemodule: 83299092a3327e4221f964f69b7abb48c2925680
-  React-graphics: 6c5a692ec20f47834b72020ebb51e203e76c0486
-  React-hermes: 101762c828f1f9c9a15010a335bf58b8576bd24e
-  React-idlecallbacksnativemodule: 3451bbbcfa4c85079370cde0cb39cf99d024728d
-  React-ImageManager: a60f8e589e3a409c433c7eddc0a53ec0fa73fcfa
-  React-jserrorhandler: 5c5a6b0a0e69c61a54645bf753fddd5f2c987740
-  React-jsi: 63c14490e7b06cdae41f8039deb5366611185c15
-  React-jsiexecutor: beda562d830c3512c8fd747541bd05e7d4f8a962
-  React-jsinspector: b620391b0e6f00a59b22fb2d69a9125ce2c0ba6a
-  React-jsinspectortracing: 8ee9c4e016208f0ec90c9beb22c8898efc99a4a4
-  React-jsitooling: 0518d7e70565a386a08d81c0ef24913e40113d37
-  React-jsitracing: 72b812a474307e315d47cbe32efb5d705be8fc98
-  React-logger: cc55ca6e50aeb31216c0a9dec30871cac776ef9a
-  React-Mapbuffer: 8df5296f9d9a61f980d293b55026cfebcd8dfb0a
-  React-microtasksnativemodule: c8ed30f8ec30affbc73411c54207bd67b1125bbb
-  react-native-maps: 401ad17cf898bf0387977897b5d087ec3e50b905
-  React-NativeModulesApple: 8a465be9a58afc56f48c1322331ffbdecd3d4877
+  React-featureflagsnativemodule: 952a24249bc9df5d22b231aa5f4fba78e87611cb
+  React-graphics: 5b92524e0c62d1d1be676883b2c3f2e20743c65f
+  React-hermes: a6f231430891844027129f0c694e286f16385eff
+  React-idlecallbacksnativemodule: af2d3dcd4767c5c0fddcc27995a15f3d32fde832
+  React-ImageManager: cb4974f0865ad621cef1b41dec8eec471d99d41b
+  React-jserrorhandler: 63ac0ec310ace3f964f0bbccbafbc2d9daddd388
+  React-jsi: 5143e8b9f4bd595ac7c1f4cbf8ab52be22ce9aeb
+  React-jsiexecutor: a999b6f38492b426e79678cd28d289f0c13c92af
+  React-jsinspector: d7c3ec67c4a7a1cf65694931cd91a20da83fd486
+  React-jsinspectortracing: 8cf14ed0943e802d3971144929b0603591271cb0
+  React-jsitooling: 5332df3e2e9962911423f957d58d86d0c7485cdd
+  React-jsitracing: 309e24851f287ba91c802082a5865f755e8e5fa1
+  React-logger: 34debb54489c4c02e5de4cc057a0943e97d2038a
+  React-Mapbuffer: 206115a22168bd42d6ef21acfe5eb5b39589ed53
+  React-microtasksnativemodule: 32f7f13d65525e981e9a5b28cebad7d10e0ff711
+  react-native-maps: 17e85d89630c56f1ba995ac2817b96907fa74989
+  React-NativeModulesApple: 6d750bb9829fdf0f02c56e9a68cbb390e1f5de25
   React-oscompat: 74eb4badd12e93899f37a5dbb03d8a638011a292
-  React-perflogger: dba4ffef10c54537fa33cb2580cf6d4c48458d36
-  React-performancetimeline: 5b63ca80ebe4796b8d95bd7972539eaf18f47590
+  React-perflogger: 53be4c46645bbccec870dd82a24764aca9bae4c2
+  React-performancetimeline: 2d5bde46eb399631b247cc705bb198959bd80065
   React-RCTActionSheet: ad2193ad50bdbfe1f801ce2e1e7e26aa7d7ce24c
-  React-RCTAnimation: cebd48779bcab78c816f4a17b2aded242bd12ff5
-  React-RCTAppDelegate: 30e83bd967f4d672d5c4d54c70dc078a77f0c273
-  React-RCTBlob: 55dba10d8afbbe27011f595408f297d92c1d45aa
-  React-RCTFabric: 5268b118423320f39c4ba35047b70e3778e0aefc
-  React-RCTFBReactNativeSpec: 3a152de585f9919590a004cad28fe10f3cf5c15a
-  React-RCTImage: d2cccc3b534a305e75faa25828aa09b31b52d6b8
-  React-RCTLinking: 057aa60f0cf05cd6501f105d849864bc32454df0
-  React-RCTNetwork: 4a668f83428976f107589f4b88c4d6239ae3b32f
-  React-RCTRuntime: 98ef28677d73ea09e428a99a22c3b81ac315275a
-  React-RCTSettings: 59f17dfe3dad01a597a68844c5949a6241600dae
-  React-RCTText: 909c0bc417d9330cd190ae28e1591893d5d8fb40
-  React-RCTVibration: 70177b2cb59d2a66f45f1c7ba085a0a03a3d4486
+  React-RCTAnimation: cc473084512605509a289104bdd6f70d9793923b
+  React-RCTAppDelegate: 03b0b07346683ed33adde449f004a1eb5602b386
+  React-RCTBlob: 8b69c14809c06d3221a1e0ea505b0935e34b07aa
+  React-RCTFabric: 06a4f8dbb59164d78b4520086af0578a43f23e1f
+  React-RCTFBReactNativeSpec: 7193baf468444cc2d24482d858295dc01df873b0
+  React-RCTImage: afc833927edbcf9632f41b55620aaba51fdd6c62
+  React-RCTLinking: 689a270cf9cb8bb45cfb69a71c2b3c0fd616d4e4
+  React-RCTNetwork: 66895396e611a6a19a084adfbd220f1f484b3d3a
+  React-RCTRuntime: 8e4fa247763268aa6b907283b575e15c4561fa16
+  React-RCTSettings: 4c021af0a5fbee0bd5b18125ce50b5dcf60e5ec6
+  React-RCTText: f178dfb1eec1df27945528d24997a9f3d4f2b74a
+  React-RCTVibration: aeb450491923d5b9954b1e118650c1bc7db501d2
   React-rendererconsistency: 628d662bf14e5ec49af779ee382280dcd65ad430
-  React-renderercss: c7cc6b3287217f39d6fb79431d8841bc7ea20179
-  React-rendererdebug: 2317cc3044bb0cdd66f4254ed2e16536a752402b
+  React-renderercss: 1e56d0a503f008253f8fcd606c11c7558b92df06
+  React-rendererdebug: 4ed0c2394d69bd1f5b2d5eb6bc760582ef5b351c
   React-rncore: d90b783a3f993a3491bd81c36d62fc843ae88528
-  React-RuntimeApple: 8d3d132c36c57f35581785b6c543ef04723c0ea3
-  React-RuntimeCore: 6d82cad0a1440703886013dfaaf79690e02caf7d
+  React-RuntimeApple: f33705526c9b42e3c23f856afc0246068fae0f8c
+  React-RuntimeCore: ed0aad8560cdc8a3c3fd4c89a4bc759920918d72
   React-runtimeexecutor: c57466c25cc95c707d2858cfc83675822927f5cc
-  React-RuntimeHermes: c057dfa7dcfc7b058aca1879842d7eb35b806cc5
-  React-runtimescheduler: 207dff7820ae2d80ab2f1ad3559cc40c10b5bc9a
+  React-RuntimeHermes: f5a835fd381b02adedb15c13b7d47ca35bea4f5e
+  React-runtimescheduler: a45cc09fd1dd0beaebdd77fb8cfb55d4d45cb824
   React-timing: 8c58486869a85e0ad592750d3545d971d6896d3f
-  React-utils: f0682aad6bd72b8402527bfc58a9965e30e396d8
-  ReactAppDependencyProvider: 642d266e12ef5ea8cb22ca9576df1f4e036258a2
-  ReactCodegen: 86758c0e13c6b245ff0cd7123cc5e8910d67546a
-  ReactCommon: aa48e4fddbc6a0afa19dca39a1b6016c150b5db4
+  React-utils: 644a5ee84adb7c86cdd0ff109c69ea99289803c8
+  ReactAppDependencyProvider: f3426eaf6dabae0baec543cd7bac588b6f59210c
+  ReactCodegen: 3288d61658273d72fbd348a74b59710b9790615f
+  ReactCommon: 9f975582dc535de1de110bdb46d4553140a77541
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: d15f5aa644c466e917569ac43b19cbf17975239a
+  SSZipArchive: fe6a26b2a54d5a0890f2567b5cc6de5caa600aef
+  Yoga: fee373fb83c58550e84555a4e6bdafc34b4c5790
 
 PODFILE CHECKSUM: 87d0653d1d9625a80ecc4a8e115f2b8557a6e8bf
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.15.2

--- a/example/src/examples/MapKml.tsx
+++ b/example/src/examples/MapKml.tsx
@@ -1,59 +1,86 @@
-import React from 'react';
-import {StyleSheet, View, Dimensions} from 'react-native';
-import MapView, {Marker} from 'react-native-maps';
+import React, {useState, useRef, useMemo} from 'react';
+import { StyleSheet, View, Dimensions, ScrollView, Button } from 'react-native';
+import MapView, {MapViewProps, Marker} from 'react-native-maps';
 
-const {width, height} = Dimensions.get('window');
+const { width, height } = Dimensions.get('window');
 
-const ASPECT_RATIO = width / height;
-const LATITUDE = -18.9193508;
-const LONGITUDE = -48.2830592;
-const LATITUDE_DELTA = 0.0922;
-const LONGITUDE_DELTA = LATITUDE_DELTA * ASPECT_RATIO;
-const KML_FILE = 'https://pastebin.com/raw/jAzGpq1F';
+const LATITUDE = 46.2276;
+const LONGITUDE = 2.2137;
+const LATITUDE_DELTA = 10;
 
-export default class MapKml extends React.Component<any, any> {
-  map: any;
-  constructor(props: any) {
-    super(props);
+const kmlFiles = [
+  'https://pastebin.com/raw/5XcSeT0b',
+  'https://pastebin.com/raw/jAzGpq1F',
+  'https://pastebin.com/raw/qwZn8dRU',
+];
 
-    this.state = {
-      region: {
-        latitude: LATITUDE,
-        longitude: LONGITUDE,
-        latitudeDelta: LATITUDE_DELTA,
-        longitudeDelta: LONGITUDE_DELTA,
-      },
-    };
+type MapKmlProps = Pick<MapViewProps, 'provider'>
 
-    this.onKmlReady = this.onKmlReady.bind(this);
-  }
+const MapKml = ({ provider }: MapKmlProps) => {
+  const mapRef = useRef<MapView>(null);
 
-  onKmlReady() {
-    this.map.fitToElements({animated: true});
-  }
+  const [selectedKmls, setSelectedKmls] = useState(new Set<string>());
 
-  render() {
-    return (
-      <View style={styles.container}>
-        <MapView
-          ref={ref => {
-            this.map = ref;
-          }}
-          provider={this.props.provider}
-          style={styles.map}
-          initialRegion={this.state.region}
-          kmlSrc={KML_FILE}
-          onKmlReady={this.onKmlReady}>
-          <Marker
-            coordinate={this.state.region}
-            title="Test"
-            description="Test"
-          />
-        </MapView>
+  const selectedKmlStr = useMemo<Array<string>>(()=> {
+    return [...selectedKmls.values()];
+  }, [selectedKmls]);
+
+  const [region] = useState({
+    latitude: LATITUDE,
+    longitude: LONGITUDE,
+    latitudeDelta: LATITUDE_DELTA,
+    longitudeDelta: LATITUDE_DELTA,
+  });
+
+  const handleKmlSelection = (kmlFile: string) => {
+    setSelectedKmls(oldSet => {
+      if (oldSet.has(kmlFile)) {
+        oldSet.delete(kmlFile);
+      }else{
+        oldSet.add(kmlFile);
+      }
+        return new Set([...oldSet]);
+    });
+  };
+
+  const handleOnKmlReady = () => {
+    mapRef.current?.animateToRegion({
+      latitude: LATITUDE,
+      longitude: LONGITUDE,
+      latitudeDelta: LATITUDE_DELTA,
+      longitudeDelta: LATITUDE_DELTA,
+    });
+  };
+
+  return (
+    <View style={styles.container}>
+      <MapView
+        ref={mapRef}
+        provider={provider}
+        style={styles.map}
+        kmlSrc={selectedKmlStr}
+        onKmlReady={handleOnKmlReady}
+      >
+        <Marker
+          coordinate={region}
+          title="Test"
+          description="Test"
+        />
+      </MapView>
+      <View style={styles.simpleKmlSelectionSheet}>
+        <ScrollView>
+          {kmlFiles.map((kmlFile, index) => (
+            <Button
+              key={kmlFile}
+              title={`file ${index} ${selectedKmls.has(kmlFile) ? '(selected)' : ''}`}
+              onPress={() => handleKmlSelection(kmlFile)}
+            />
+          ))}
+        </ScrollView>
       </View>
-    );
-  }
-}
+    </View>
+  );
+};
 
 const styles = StyleSheet.create({
   container: {
@@ -69,4 +96,9 @@ const styles = StyleSheet.create({
     width,
     height,
   },
+  simpleKmlSelectionSheet: {
+    height: '20%',
+  },
 });
+
+export default MapKml;

--- a/example/src/examples/MapKml.tsx
+++ b/example/src/examples/MapKml.tsx
@@ -15,15 +15,15 @@ type KmlEntry = {
 
 
 const kmlFiles = [{
-  label: "Remote kmz",
+  label: 'Remote kmz',
   file: 'https://www.google.com/maps/d/u/0/kml?mid=12u1KMaAe02f5iDEMEYeIcXGaUJd_54Y&cid=mp&cv=czMHwAlgGtA.fr.',
 },
 {
-  label: "Remote kml",
+  label: 'Remote kml',
   file: 'https://pastebin.com/raw/5XcSeT0b',
 },
 {
-  label: "Remote kml 2",
+  label: 'Remote kml 2',
   file: 'https://pastebin.com/raw/qwZn8dRU',
 }] satisfies Array<KmlEntry>;
 
@@ -57,7 +57,7 @@ const MapKml = ({ provider }: MapKmlProps) => {
   };
 
   const handleOnKmlReady = () => {
-    console.log("onKmlReady called");
+    console.log('onKmlReady called');
     mapRef.current?.animateToRegion({
       latitude: LATITUDE,
       longitude: LONGITUDE,

--- a/example/src/examples/MapKml.tsx
+++ b/example/src/examples/MapKml.tsx
@@ -1,8 +1,8 @@
 import React, {useState, useRef, useMemo} from 'react';
-import { StyleSheet, View, Dimensions, ScrollView, Button } from 'react-native';
+import {StyleSheet, View, Dimensions, ScrollView, Button} from 'react-native';
 import MapView, {MapViewProps, Marker} from 'react-native-maps';
 
-const { width, height } = Dimensions.get('window');
+const {width, height} = Dimensions.get('window');
 
 const LATITUDE = 46.2276;
 const LONGITUDE = 2.2137;
@@ -13,28 +13,29 @@ type KmlEntry = {
   file: string;
 };
 
+const kmlFiles = [
+  {
+    label: 'Remote kmz',
+    file: 'https://www.google.com/maps/d/u/0/kml?mid=12u1KMaAe02f5iDEMEYeIcXGaUJd_54Y&cid=mp&cv=czMHwAlgGtA.fr.',
+  },
+  {
+    label: 'Remote kml',
+    file: 'https://pastebin.com/raw/5XcSeT0b',
+  },
+  {
+    label: 'Remote kml 2',
+    file: 'https://pastebin.com/raw/qwZn8dRU',
+  },
+] satisfies Array<KmlEntry>;
 
-const kmlFiles = [{
-  label: 'Remote kmz',
-  file: 'https://www.google.com/maps/d/u/0/kml?mid=12u1KMaAe02f5iDEMEYeIcXGaUJd_54Y&cid=mp&cv=czMHwAlgGtA.fr.',
-},
-{
-  label: 'Remote kml',
-  file: 'https://pastebin.com/raw/5XcSeT0b',
-},
-{
-  label: 'Remote kml 2',
-  file: 'https://pastebin.com/raw/qwZn8dRU',
-}] satisfies Array<KmlEntry>;
+type MapKmlProps = Pick<MapViewProps, 'provider'>;
 
-type MapKmlProps = Pick<MapViewProps, 'provider'>
-
-const MapKml = ({ provider }: MapKmlProps) => {
+const MapKml = ({provider}: MapKmlProps) => {
   const mapRef = useRef<MapView>(null);
 
   const [selectedKmls, setSelectedKmls] = useState(new Set<KmlEntry>());
 
-  const selectedKmlStr = useMemo<Array<string>>(()=> {
+  const selectedKmlStr = useMemo<Array<string>>(() => {
     return [...selectedKmls.values()].map(entry => entry.file);
   }, [selectedKmls]);
 
@@ -49,10 +50,10 @@ const MapKml = ({ provider }: MapKmlProps) => {
     setSelectedKmls(oldSet => {
       if (oldSet.has(kmlFile)) {
         oldSet.delete(kmlFile);
-      }else{
+      } else {
         oldSet.add(kmlFile);
       }
-        return new Set([...oldSet]);
+      return new Set([...oldSet]);
     });
   };
 
@@ -78,7 +79,7 @@ const MapKml = ({ provider }: MapKmlProps) => {
       </MapView>
       <View style={styles.simpleKmlSelectionSheet}>
         <ScrollView>
-          {kmlFiles.map((kmlEntry) => (
+          {kmlFiles.map(kmlEntry => (
             <Button
               key={kmlEntry.label}
               title={`${kmlEntry.label} ${

--- a/example/src/examples/MapKml.tsx
+++ b/example/src/examples/MapKml.tsx
@@ -8,21 +8,34 @@ const LATITUDE = 46.2276;
 const LONGITUDE = 2.2137;
 const LATITUDE_DELTA = 10;
 
-const kmlFiles = [
-  'https://pastebin.com/raw/5XcSeT0b',
-  'https://pastebin.com/raw/jAzGpq1F',
-  'https://pastebin.com/raw/qwZn8dRU',
-];
+type KmlEntry = {
+  label: string;
+  file: string;
+};
+
+
+const kmlFiles = [{
+  label: "Remote kmz",
+  file: 'https://www.google.com/maps/d/u/0/kml?mid=12u1KMaAe02f5iDEMEYeIcXGaUJd_54Y&cid=mp&cv=czMHwAlgGtA.fr.',
+},
+{
+  label: "Remote kml",
+  file: 'https://pastebin.com/raw/5XcSeT0b',
+},
+{
+  label: "Remote kml 2",
+  file: 'https://pastebin.com/raw/qwZn8dRU',
+}] satisfies Array<KmlEntry>;
 
 type MapKmlProps = Pick<MapViewProps, 'provider'>
 
 const MapKml = ({ provider }: MapKmlProps) => {
   const mapRef = useRef<MapView>(null);
 
-  const [selectedKmls, setSelectedKmls] = useState(new Set<string>());
+  const [selectedKmls, setSelectedKmls] = useState(new Set<KmlEntry>());
 
   const selectedKmlStr = useMemo<Array<string>>(()=> {
-    return [...selectedKmls.values()];
+    return [...selectedKmls.values()].map(entry => entry.file);
   }, [selectedKmls]);
 
   const [region] = useState({
@@ -32,7 +45,7 @@ const MapKml = ({ provider }: MapKmlProps) => {
     longitudeDelta: LATITUDE_DELTA,
   });
 
-  const handleKmlSelection = (kmlFile: string) => {
+  const handleKmlSelection = (kmlFile: KmlEntry) => {
     setSelectedKmls(oldSet => {
       if (oldSet.has(kmlFile)) {
         oldSet.delete(kmlFile);
@@ -59,21 +72,18 @@ const MapKml = ({ provider }: MapKmlProps) => {
         provider={provider}
         style={styles.map}
         kmlSrc={selectedKmlStr}
-        onKmlReady={handleOnKmlReady}
-      >
-        <Marker
-          coordinate={region}
-          title="Test"
-          description="Test"
-        />
+        onKmlReady={handleOnKmlReady}>
+        <Marker coordinate={region} title="Test" description="Test" />
       </MapView>
       <View style={styles.simpleKmlSelectionSheet}>
         <ScrollView>
-          {kmlFiles.map((kmlFile, index) => (
+          {kmlFiles.map((kmlEntry) => (
             <Button
-              key={kmlFile}
-              title={`file ${index} ${selectedKmls.has(kmlFile) ? '(selected)' : ''}`}
-              onPress={() => handleKmlSelection(kmlFile)}
+              key={kmlEntry.label}
+              title={`${kmlEntry.label} ${
+                selectedKmls.has(kmlEntry) ? '(selected)' : ''
+              }`}
+              onPress={() => handleKmlSelection(kmlEntry)}
             />
           ))}
         </ScrollView>

--- a/example/src/examples/MapKml.tsx
+++ b/example/src/examples/MapKml.tsx
@@ -57,6 +57,7 @@ const MapKml = ({ provider }: MapKmlProps) => {
   };
 
   const handleOnKmlReady = () => {
+    console.log("onKmlReady called");
     mapRef.current?.animateToRegion({
       latitude: LATITUDE,
       longitude: LONGITUDE,

--- a/ios/AirGoogleMaps/AIRGoogleMap.h
+++ b/ios/AirGoogleMaps/AIRGoogleMap.h
@@ -13,6 +13,7 @@
 #import <GoogleMaps/GoogleMaps.h>
 #import <MapKit/MapKit.h>
 #import "AIRGMSMarker.h"
+#import "GMUGeometryRenderer.h"
 
 #import "AIRGoogleMapCoordinate.h"
 
@@ -51,6 +52,8 @@
 @property (nonatomic, strong) NSMutableArray *heatmaps;
 @property (nonatomic, strong) NSMutableArray *tiles;
 @property (nonatomic, strong) NSMutableArray *overlays;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, GMUGeometryRenderer *> *kmlLayers;
+@property (nonatomic, strong) NSMutableArray<NSString *> *kmlSrc;
 
 @property (nonatomic, assign) BOOL showsBuildings;
 @property (nonatomic, assign) BOOL showsTraffic;
@@ -65,7 +68,6 @@
 @property (nonatomic, assign) BOOL showsMyLocationButton;
 @property (nonatomic, assign) BOOL showsIndoors;
 @property (nonatomic, assign) BOOL showsIndoorLevelPicker;
-@property (nonatomic, assign) NSString *kmlSrc;
 
 - (BOOL) isReady;
 - (void)didPrepareMap;

--- a/ios/AirGoogleMaps/AIRGoogleMap.h
+++ b/ios/AirGoogleMaps/AIRGoogleMap.h
@@ -52,7 +52,6 @@
 @property (nonatomic, strong) NSMutableArray *heatmaps;
 @property (nonatomic, strong) NSMutableArray *tiles;
 @property (nonatomic, strong) NSMutableArray *overlays;
-@property (nonatomic, strong) NSMutableDictionary<NSString *, GMUGeometryRenderer *> *kmlLayers;
 @property (nonatomic, strong) NSMutableArray<NSString *> *kmlSrc;
 
 @property (nonatomic, assign) BOOL showsBuildings;

--- a/ios/AirGoogleMaps/AIRGoogleMap.mm
+++ b/ios/AirGoogleMaps/AIRGoogleMap.mm
@@ -469,10 +469,10 @@ id regionAsJSON(MKCoordinateRegion region) {
   id event = @{@"action": @"marker-press",
                @"id": airMarker.identifier ?: @"unknown",
                @"coordinate": @{
-                   @"latitude": @(airMarker.position.latitude),
-                   @"longitude": @(airMarker.position.longitude)
-                   }
-               };
+                 @"latitude": @(airMarker.position.latitude),
+                 @"longitude": @(airMarker.position.longitude)
+               }
+  };
 
   if (airMarker.onPress) airMarker.onPress(event);
   if (self.onMarkerPress) self.onMarkerPress(event);

--- a/ios/AirGoogleMaps/AIRGoogleMapManager.mm
+++ b/ios/AirGoogleMaps/AIRGoogleMapManager.mm
@@ -125,7 +125,7 @@ RCT_EXPORT_VIEW_PROPERTY(onIndoorBuildingFocused, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(mapType, GMSMapViewType)
 RCT_EXPORT_VIEW_PROPERTY(minZoomLevel, CGFloat)
 RCT_EXPORT_VIEW_PROPERTY(maxZoomLevel, CGFloat)
-RCT_EXPORT_VIEW_PROPERTY(kmlSrc, NSString)
+RCT_EXPORT_VIEW_PROPERTY(kmlSrc, NSArray)
 RCT_EXPORT_VIEW_PROPERTY(loadingBackgroundColor, UIColor)
 
 RCT_EXPORT_METHOD(getCamera:(nonnull NSNumber *)reactTag

--- a/ios/AirGoogleMaps/AIRKmlDocumentManager.h
+++ b/ios/AirGoogleMaps/AIRKmlDocumentManager.h
@@ -1,0 +1,25 @@
+// AIRKmlDocumentManager.h
+
+
+#ifdef HAVE_GOOGLE_MAPS
+
+#import <Foundation/Foundation.h>
+#import "GMUKMLParser.h"
+#import "GMUGeometryRenderer.h"
+#import <React/RCTComponent.h>
+#import <React/RCTBridge.h>
+
+@interface AIRKmlDocumentManager : NSObject
+
+@property (nonatomic, strong) NSMutableDictionary<NSString *, GMUGeometryRenderer *> *kmlLayers;
+@property (nonatomic, copy) RCTBubblingEventBlock onKmlReady;
+
+
+- (instancetype)initWithMapView:(GMSMapView *)mapView;
+- (void)setKmlSrc:(NSMutableArray<NSString *> *)kmlSrcList;
+- (void)addKmlSrc:(NSString *)kmlSrc withGroup:(dispatch_group_t)group;
+- (void)removeKmlSrc:(NSString *)kmlSrc;
+
+@end
+
+#endif

--- a/ios/AirGoogleMaps/AIRKmlDocumentManager.h
+++ b/ios/AirGoogleMaps/AIRKmlDocumentManager.h
@@ -17,8 +17,6 @@
 
 - (instancetype)initWithMapView:(GMSMapView *)mapView;
 - (void)setKmlSrc:(NSMutableArray<NSString *> *)kmlSrcList;
-- (void)addKmlSrc:(NSString *)kmlSrc withGroup:(dispatch_group_t)group;
-- (void)removeKmlSrc:(NSString *)kmlSrc;
 
 @end
 

--- a/ios/AirGoogleMaps/AIRKmlDocumentManager.m
+++ b/ios/AirGoogleMaps/AIRKmlDocumentManager.m
@@ -101,14 +101,6 @@ static const uint8_t kZipMagic[4] = {0x50, 0x4B, 0x03, 0x04}; // â€œPK\003\004â€
     return;
   }
 
-  // We have a remote url, we first check if it has already been downloaded
-  if ([self isKmlDocumentCached:kmlSrc]) {
-    NSString *generatedKmzPath =  [self getDeterministicPathForKey:kmlSrc extension:@"kmz"];
-    NSLog(@"Kmz file already downloaded at %@", generatedKmzPath);
-    [self renderKMZ:[NSURL fileURLWithPath: generatedKmzPath] sourceKey:kmlSrc];
-    return;
-  }
-
 
   __weak typeof(self) weakSelf = self;
 
@@ -409,12 +401,6 @@ static const uint8_t kZipMagic[4] = {0x50, 0x4B, 0x03, 0x04}; // â€œPK\003\004â€
   GMUGeometryRenderer *renderer = self.kmlLayers[kmlSrc];
   [renderer clear];
   [self.kmlLayers removeObjectForKey:kmlSrc];
-}
-
-
-- (BOOL)isKmlDocumentCached:(NSString*) sourceKey{
-  NSString *generatedKmzPath =  [self getDeterministicPathForKey:sourceKey extension:@"kmz"];
-  return [self.fileManager fileExistsAtPath:generatedKmzPath];
 }
 
 - (NSFileManager *)fileManager {

--- a/ios/AirGoogleMaps/AIRKmlDocumentManager.m
+++ b/ios/AirGoogleMaps/AIRKmlDocumentManager.m
@@ -1,0 +1,443 @@
+// AIRKmlDocumentManager.m
+
+#ifdef HAVE_GOOGLE_MAPS
+
+#import "AIRKmlDocumentManager.h"
+#import <SSZipArchive/SSZipArchive.h>
+#import <CommonCrypto/CommonDigest.h>
+
+
+#ifdef HAVE_GOOGLE_MAPS_UTILS
+#import "AIRGoogleMap.h"
+#import "GMUKMLParser.h"
+#import "GMUPlacemark.h"
+#import "GMUPoint.h"
+#import "GMUGeometryRenderer.h"
+#define REQUIRES_GOOGLE_MAPS_UTILS(feature) do {} while (0)
+#else
+#define GMUKMLParser void
+#define GMUPlacemark void
+#define REQUIRES_GOOGLE_MAPS_UTILS(feature) do { \
+[NSException raise:@"ReactNativeMapsDependencyMissing" \
+format:@"Use of " feature "requires Google-Maps-iOS-Utils, you  must install via CocoaPods to use this feature"]; \
+} while (0)
+#endif
+
+
+static const uint8_t kZipMagic[4] = {0x50, 0x4B, 0x03, 0x04}; // “PK\003\004”
+
+
+@interface AIRKmlDocumentManager ()
+
+@property (nonatomic, strong) NSFileManager *fileManager;
+@property (nonatomic, weak) AIRGoogleMap *mapView;
+
+@end
+
+@implementation AIRKmlDocumentManager
+
+- (instancetype)initWithMapView:(AIRGoogleMap *)mapView {
+  self = [super init];
+  if (self) {
+    _mapView = mapView;
+    _kmlLayers = [[NSMutableDictionary alloc] init];
+    _fileManager = [NSFileManager defaultManager];
+  }
+  return self;
+}
+
+
+/**
+ * Synchronizes the displayed KML/KMZ layers with a new source list.
+ *
+ * - Removes any previously loaded KML/KMZ documents that are no longer in the provided list.
+ * - Adds and parses any new KML/KMZ sources that are missing.
+ *
+ * @param kmlSrcList A mutable array of NSString URLs (local or remote) representing KML or KMZ documents to load.
+ */
+- (void)setKmlSrc:(NSMutableArray<NSString *> *)kmlSrcList {
+#ifdef HAVE_GOOGLE_MAPS_UTILS
+
+  dispatch_group_t group = dispatch_group_create();
+
+  for (NSString *url in [self.kmlLayers allKeys]) {
+    if (![kmlSrcList containsObject:url]) {
+      [self removeKmlSrc:url];
+    }
+  }
+
+  for (NSString *url in kmlSrcList) {
+    if (![self.kmlLayers objectForKey:url]) {
+      [self addKmlSrc:url withGroup:group];
+    }
+  }
+
+  dispatch_group_notify(group, dispatch_get_main_queue(), ^{
+    if (self.mapView.onKmlReady) {
+      if (kmlSrcList.count > 0 || [self.kmlLayers allKeys].count > 0) {
+        self.mapView.onKmlReady(@{});
+      }
+    }
+  });
+
+#else
+  REQUIRES_GOOGLE_MAPS_UTILS();
+#endif
+}
+
+
+/**
+ * Adds and renders a single KML or KMZ source URL.
+ *
+ * @param kmlSrc A string representing a local or remote URL for a KML or KMZ document.
+ * @param group  A dispatch group used to track completion of loading and parsing operations.
+ */
+- (void)addKmlSrc:(NSString *)kmlSrc withGroup:(dispatch_group_t)group {
+
+  // Check if it's a local file
+  NSURL *url = [NSURL URLWithString:kmlSrc];
+  if (url.isFileURL) {
+    [self renderLocalKmlDocument:url sourceKey:kmlSrc];
+    return;
+  }
+
+  // We have a remote url, we first check if it has already been downloaded
+  if ([self isKmlDocumentCached:kmlSrc]) {
+    NSString *generatedKmzPath =  [self getDeterministicPathForKey:kmlSrc extension:@"kmz"];
+    NSLog(@"Kmz file already downloaded at %@", generatedKmzPath);
+    [self renderKMZ:[NSURL fileURLWithPath: generatedKmzPath] sourceKey:kmlSrc];
+    return;
+  }
+
+
+  __weak typeof(self) weakSelf = self;
+
+  dispatch_group_enter(group);
+  // Download file from network
+  [[[NSURLSession sharedSession] dataTaskWithURL:url
+                               completionHandler:^(NSData *data,
+                                                   NSURLResponse *resp,
+                                                   NSError *err)
+    {
+    __strong typeof(weakSelf) self = weakSelf;
+    
+    if (!self) { dispatch_group_leave(group); return; }
+
+    if (err) {
+      NSLog(@"[KML] download error: %@", err.localizedDescription);
+      dispatch_group_leave(group);
+      return;
+    }
+
+    if ([self isZipData:data]) {
+      [self writeKmzToDisk:data sourceKey:kmlSrc completion:^(NSURL *localZipURL, NSError *error) {
+        if (error) {
+          NSLog(@"Failed to save KMZ: %@", error.localizedDescription);
+          dispatch_group_leave(group);
+          return;
+        }
+
+        [self renderKMZ:localZipURL sourceKey:kmlSrc];
+        dispatch_group_leave(group);
+      }];
+    } else {
+      [self renderKml:data sourceKey:kmlSrc];
+      dispatch_group_leave(group);
+    }
+  }] resume];
+}
+
+
+/**
+ * Renders a local KML document (.kml or .kmz).
+ *
+ * - If the URL points to a plain .kml file, it parses and renders it directly.
+ * - If the URL points to a compressed .kmz archive, it delegates to `renderKMZ:sourceKey:group:`.
+ */
+- (void)renderLocalKmlDocument:(NSURL *)url sourceKey:(NSString *)key {
+
+  NSError *error = nil;
+  NSData *data = [NSData dataWithContentsOfURL:url options:0 error:&error];
+  if (!data) {
+    NSLog(@"[KML] Failed to read local file: %@", error.localizedDescription);
+    return;
+  }
+
+  if ([self isZipData:data]) {
+    [self renderKMZ:url sourceKey:key];
+  } else {
+    [self renderKml:data sourceKey:key];
+  }
+}
+
+/**
+ * Parses and renders KML data onto the map.
+ *
+ * @param data  The KML data to parse and render.
+ * @param key   A unique source key used to track the rendered KML layer.
+ */
+- (void)renderKml:(NSData *)data
+        sourceKey:(NSString *)key {
+
+  GMUKMLParser *parser = [[GMUKMLParser alloc] initWithData:data];
+  [parser parse];
+
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [self renderKmlFromParser:parser withStyles:parser.styles sourceKey:key];
+  });
+}
+
+
+/**
+ * Unzips and renders a local KMZ archive (.kmz).
+ *
+ * - Unzips the KMZ archive into a temporary, deterministic directory based on `sourceKey`.
+ * - Looks for the `doc.kml` file inside the unzipped folder.
+ * - Parses and renders the extracted KML content and associated styles.
+ * - Updates any relative icon URLs to absolute file URLs pointing inside the temporary directory.
+ */
+- (void)renderKMZ:(NSURL *)zipURL
+        sourceKey:(NSString *)key {
+
+  NSError  *err = nil;
+  NSString *unzipDir = [self createTempDirectoryForKey:key error:&err];
+
+  if (!unzipDir) {
+    NSLog(@"[KML] temp-file error: %@", err.localizedDescription);
+    return;
+  }
+
+  if (![SSZipArchive unzipFileAtPath:zipURL.path toDestination:unzipDir]) {
+    NSLog(@"[KML] unzip failed for %@", zipURL.lastPathComponent);
+    return;
+  }
+
+  NSString *docPath = [unzipDir stringByAppendingPathComponent:@"doc.kml"];
+  if (![self.fileManager fileExistsAtPath:docPath]) {
+    NSLog(@"[KML] doc.kml not found inside %@", zipURL.lastPathComponent);
+    return;
+  }
+
+  GMUKMLParser *parser = [[GMUKMLParser alloc] initWithURL:[NSURL fileURLWithPath:docPath]];
+  [parser parse];
+
+  NSArray<GMUStyle *> *fixedStyles =
+  [self stylesByFixingIcons:parser.styles baseDir:unzipDir];
+
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [self renderKmlFromParser:parser
+                   withStyles:fixedStyles
+                    sourceKey:key];
+  });
+
+}
+
+
+/**
+ *Writes a remote or in-memory KMZ data to a local temp file.
+ *Calls completion with the resulting file URL, or error if failed.
+ */
+- (void)writeKmzToDisk:(NSData *)data
+             sourceKey:(NSString *)key
+            completion:(void (^)(NSURL * _Nullable localZipUrl, NSError * _Nullable error))completion
+{
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
+
+    NSError *err = nil;
+    NSString *generatedPath =  [self getDeterministicPathForKey:key extension:@"kmz"];
+    NSURL *localZipURL   = [self writeData:data path:generatedPath error:&err];
+
+    if (!localZipURL) {
+      dispatch_async(dispatch_get_main_queue(), ^{
+        if (completion) completion(nil, err);
+      });
+      return;
+    }
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+      if (completion) completion(localZipURL, nil);
+    });
+  });
+}
+
+
+
+/**
+ * Adjusts the icon URLs in an array of GMUStyle objects to ensure they are absolute paths.
+ *
+ * This method iterates over an array of GMUStyle objects and modifies the icon URLs
+ * to be absolute paths if they are currently relative paths. It does this by appending
+ * the relative path to the provided base directory. If the icon URL is already an
+ * absolute path (starting with "http://", "https://", or "/"), it remains unchanged.
+ *
+ * @param styles An array of GMUStyle objects whose icon URLs need to be fixed.
+ * @param baseDir The base directory to use for converting relative icon paths to absolute paths.
+ * @return A new array of GMUStyle objects with fixed icon URLs.
+ */
+- (NSArray<GMUStyle *> *)stylesByFixingIcons:(NSArray<GMUStyle *> *)styles
+                                     baseDir:(NSString *)baseDir {
+
+  NSMutableArray *newStyles = [NSMutableArray arrayWithCapacity:styles.count];
+
+  for (GMUStyle *style in styles) {
+    NSString *icon = style.iconUrl;
+
+    // change only relative paths
+    if (icon.length &&
+        ![icon hasPrefix:@"http://"] &&
+        ![icon hasPrefix:@"https://"] &&
+        ![icon hasPrefix:@"/"])
+    {
+      NSString *absIconPath =
+      [baseDir stringByAppendingPathComponent:icon];
+      icon = [NSURL fileURLWithPath:absIconPath].absoluteString;
+    }
+
+    GMUStyle *s = [[GMUStyle alloc] initWithStyleID:style.styleID
+                                        strokeColor:style.strokeColor
+                                          fillColor:style.fillColor
+                                              width:style.width
+                                              scale:style.scale
+                                            heading:style.heading
+                                             anchor:style.anchor
+                                            iconUrl:icon
+                                              title:style.title
+                                            hasFill:style.hasFill
+                                          hasStroke:style.hasStroke];
+    [newStyles addObject:s];
+  }
+  return newStyles;
+}
+
+
+/**
+ * Renders parsed KML geometry onto the map using the provided styles.
+ *
+ * - Initializes a `GMUGeometryRenderer` with the given KML parser results and styles.
+ * - Renders all placemarks and geometries immediately onto the associated map view.
+ * - Caches the renderer instance in `kmlLayers` using the provided source key for future management (e.g., removal).
+ *
+ * @param parser  A `GMUKMLParser` instance containing parsed KML data (placemarks, geometries, and style maps).
+ * @param styles  An array of `GMUStyle` objects to apply to the parsed geometries.
+ * @param key     A unique source key identifying the rendered KML layer.
+ */
+- (void)renderKmlFromParser:(GMUKMLParser *)parser
+                 withStyles:(NSArray<GMUStyle *> *)styles
+                  sourceKey:(NSString *)key {
+
+  GMUGeometryRenderer *renderer =
+  [[GMUGeometryRenderer alloc] initWithMap:self.mapView
+                                geometries:parser.placemarks
+                                    styles:styles
+                                 styleMaps:parser.styleMaps];
+
+  [renderer render];
+  self.kmlLayers[key] = renderer;
+}
+
+/**
+ * Generates a deterministic file path in the temporary directory based on a SHA-256 hash of the given key.
+ *
+ * @param key A unique string used to generate the deterministic filename.
+ * @param ext The file extension to append (e.g., "kmz", "kml").
+ * @return A full temporary file path as an NSString.
+ */
+- (NSString *)getDeterministicPathForKey:(NSString *)key
+                               extension:(NSString *)ext {
+
+  NSString *hashedName   = [[self hashStringSHA256:key] stringByAppendingPathExtension:ext];
+  NSString *path         = [NSTemporaryDirectory() stringByAppendingPathComponent:hashedName];
+
+  return path;
+}
+
+
+/**
+ * Writes data to a specified path if it does not already exist.
+ *
+ * @param data The NSData object to write to disk.
+ * @param path The full filesystem path where the data should be written.
+ * @param err  An optional pointer to an NSError object to capture writing errors.
+ * @return A file URL pointing to the written data, or nil on failure.
+ */
+- (NSURL *)writeData:(NSData *)data
+                path:(NSString *)path
+               error:(NSError *__autoreleasing *)err {
+
+  // If the file already exists we reuse it.
+  if (![self.fileManager fileExistsAtPath:path]) {
+    if (![data writeToFile:path options:NSDataWritingAtomic error:err]) {
+      return nil;
+    }
+  }
+  return [NSURL fileURLWithPath:path];
+}
+
+
+/**
+ * Creates a deterministic temporary directory based on a SHA-256 hash of the given key.
+ *
+ * @param key A unique string used to generate the directory name.
+ * @param err An optional pointer to an NSError object to capture creation errors.
+ * @return The full path to the created (or existing) directory, or nil if creation failed.
+ */
+- (NSString *)createTempDirectoryForKey:(NSString *)key
+                                  error:(NSError *__autoreleasing *)err
+{
+  NSString *dir = [NSTemporaryDirectory()
+                   stringByAppendingPathComponent:
+                     [[self hashStringSHA256:key] stringByAppendingString:@".unzipped"]];
+
+
+  if (![self.fileManager fileExistsAtPath:dir]) {
+    if (![self.fileManager createDirectoryAtPath:dir
+                     withIntermediateDirectories:YES
+                                      attributes:nil
+                                           error:err]) {
+      return nil;
+    }
+  }
+  return dir;
+}
+
+/**
+ * Removes a previously rendered KML layer associated with the given source key.
+ *
+ * @param kmlSrc The source key identifying the KML layer to remove.
+ */
+- (void)removeKmlSrc:(NSString *)kmlSrc {
+  GMUGeometryRenderer *renderer = self.kmlLayers[kmlSrc];
+  [renderer clear];
+  [self.kmlLayers removeObjectForKey:kmlSrc];
+}
+
+
+- (BOOL)isKmlDocumentCached:(NSString*) sourceKey{
+  NSString *generatedKmzPath =  [self getDeterministicPathForKey:sourceKey extension:@"kmz"];
+  return [self.fileManager fileExistsAtPath:generatedKmzPath];
+}
+
+- (NSFileManager *)fileManager {
+  if (!_fileManager) _fileManager = [NSFileManager defaultManager];
+  return _fileManager;
+}
+
+- (BOOL)isZipData:(NSData *)data {
+  return data.length >= 4 && memcmp(data.bytes, kZipMagic, 4) == 0;
+}
+
+
+- (NSString *)hashStringSHA256:(NSString *)input {
+  const char *bytes = input.UTF8String;
+  uint8_t digest[CC_SHA256_DIGEST_LENGTH];
+  CC_SHA256(bytes, (CC_LONG)strlen(bytes), digest);
+  NSMutableString *hex = [NSMutableString stringWithCapacity:CC_SHA256_DIGEST_LENGTH * 2];
+  for (int i = 0; i < CC_SHA256_DIGEST_LENGTH; i++) {
+    [hex appendFormat:@"%02x", digest[i]];
+  }
+  return hex;
+}
+
+@end
+
+#endif

--- a/ios/AirGoogleMaps/RNMapsGoogleMapView.mm
+++ b/ios/AirGoogleMaps/RNMapsGoogleMapView.mm
@@ -593,7 +593,15 @@ using namespace facebook::react;
     REMAP_MAPVIEW_PROP(zoomTapEnabled)
     REMAP_MAPVIEW_PROP(scrollEnabled)
 
-    REMAP_MAPVIEW_STRING_PROP(kmlSrc)
+    if (oldViewProps.kmlSrc != newViewProps.kmlSrc) {
+        NSMutableArray<NSString *> *kmlArray = [NSMutableArray array];
+        for (const auto &src : newViewProps.kmlSrc) {
+            [kmlArray addObject:[NSString stringWithUTF8String:src.c_str()]];
+        }
+        _view.kmlSrc = kmlArray;
+    }
+    
+    
     REMAP_MAPVIEW_STRING_PROP(customMapStyleString)
 
 

--- a/ios/generated/RNMapsSpecs/ComponentDescriptors.cpp
+++ b/ios/generated/RNMapsSpecs/ComponentDescriptors.cpp
@@ -24,6 +24,8 @@ registry->add(concreteComponentDescriptorProvider<RNMapsMapViewComponentDescript
 registry->add(concreteComponentDescriptorProvider<RNMapsMarkerComponentDescriptor>());
 registry->add(concreteComponentDescriptorProvider<RNMapsOverlayComponentDescriptor>());
 registry->add(concreteComponentDescriptorProvider<RNMapsPolylineComponentDescriptor>());
+registry->add(concreteComponentDescriptorProvider<RNMapsUrlTileComponentDescriptor>());
+registry->add(concreteComponentDescriptorProvider<RNMapsWMSTileComponentDescriptor>());
 }
 
 } // namespace facebook::react

--- a/ios/generated/RNMapsSpecs/ComponentDescriptors.h
+++ b/ios/generated/RNMapsSpecs/ComponentDescriptors.h
@@ -24,6 +24,8 @@ using RNMapsMapViewComponentDescriptor = ConcreteComponentDescriptor<RNMapsMapVi
 using RNMapsMarkerComponentDescriptor = ConcreteComponentDescriptor<RNMapsMarkerShadowNode>;
 using RNMapsOverlayComponentDescriptor = ConcreteComponentDescriptor<RNMapsOverlayShadowNode>;
 using RNMapsPolylineComponentDescriptor = ConcreteComponentDescriptor<RNMapsPolylineShadowNode>;
+using RNMapsUrlTileComponentDescriptor = ConcreteComponentDescriptor<RNMapsUrlTileShadowNode>;
+using RNMapsWMSTileComponentDescriptor = ConcreteComponentDescriptor<RNMapsWMSTileShadowNode>;
 
 void RNMapsSpecs_registerComponentDescriptorsFromCodegen(
   std::shared_ptr<const ComponentDescriptorProviderRegistry> registry);

--- a/ios/generated/RNMapsSpecs/EventEmitters.cpp
+++ b/ios/generated/RNMapsSpecs/EventEmitters.cpp
@@ -974,4 +974,6 @@ $payload.setProperty(runtime, "id", $event.id);
   });
 }
 
+
+
 } // namespace facebook::react

--- a/ios/generated/RNMapsSpecs/EventEmitters.h
+++ b/ios/generated/RNMapsSpecs/EventEmitters.h
@@ -843,4 +843,18 @@ class RNMapsPolylineEventEmitter : public ViewEventEmitter {
     };
   void onPress(OnPress value) const;
 };
+class RNMapsUrlTileEventEmitter : public ViewEventEmitter {
+ public:
+  using ViewEventEmitter::ViewEventEmitter;
+
+  
+  
+};
+class RNMapsWMSTileEventEmitter : public ViewEventEmitter {
+ public:
+  using ViewEventEmitter::ViewEventEmitter;
+
+  
+  
+};
 } // namespace facebook::react

--- a/ios/generated/RNMapsSpecs/Props.cpp
+++ b/ios/generated/RNMapsSpecs/Props.cpp
@@ -131,6 +131,7 @@ RNMapsMapViewProps::RNMapsMapViewProps(
     tintColor(convertRawProp(context, rawProps, "tintColor", sourceProps.tintColor, {})),
     toolbarEnabled(convertRawProp(context, rawProps, "toolbarEnabled", sourceProps.toolbarEnabled, {true})),
     userInterfaceStyle(convertRawProp(context, rawProps, "userInterfaceStyle", sourceProps.userInterfaceStyle, {RNMapsMapViewUserInterfaceStyle::System})),
+    customMapStyleString(convertRawProp(context, rawProps, "customMapStyleString", sourceProps.customMapStyleString, {})),
     userLocationAnnotationTitle(convertRawProp(context, rawProps, "userLocationAnnotationTitle", sourceProps.userLocationAnnotationTitle, {})),
     userLocationCalloutEnabled(convertRawProp(context, rawProps, "userLocationCalloutEnabled", sourceProps.userLocationCalloutEnabled, {false})),
     userLocationFastestInterval(convertRawProp(context, rawProps, "userLocationFastestInterval", sourceProps.userLocationFastestInterval, {5000})),
@@ -189,6 +190,38 @@ RNMapsPolylineProps::RNMapsPolylineProps(
     strokeColors(convertRawProp(context, rawProps, "strokeColors", sourceProps.strokeColors, {})),
     strokeWidth(convertRawProp(context, rawProps, "strokeWidth", sourceProps.strokeWidth, {0.0})),
     tappable(convertRawProp(context, rawProps, "tappable", sourceProps.tappable, {false}))
+      {}
+RNMapsUrlTileProps::RNMapsUrlTileProps(
+    const PropsParserContext &context,
+    const RNMapsUrlTileProps &sourceProps,
+    const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
+
+    doubleTileSize(convertRawProp(context, rawProps, "doubleTileSize", sourceProps.doubleTileSize, {false})),
+    flipY(convertRawProp(context, rawProps, "flipY", sourceProps.flipY, {false})),
+    maximumNativeZ(convertRawProp(context, rawProps, "maximumNativeZ", sourceProps.maximumNativeZ, {100})),
+    maximumZ(convertRawProp(context, rawProps, "maximumZ", sourceProps.maximumZ, {100})),
+    minimumZ(convertRawProp(context, rawProps, "minimumZ", sourceProps.minimumZ, {0})),
+    offlineMode(convertRawProp(context, rawProps, "offlineMode", sourceProps.offlineMode, {false})),
+    shouldReplaceMapContent(convertRawProp(context, rawProps, "shouldReplaceMapContent", sourceProps.shouldReplaceMapContent, {false})),
+    tileCacheMaxAge(convertRawProp(context, rawProps, "tileCacheMaxAge", sourceProps.tileCacheMaxAge, {0})),
+    tileCachePath(convertRawProp(context, rawProps, "tileCachePath", sourceProps.tileCachePath, {})),
+    tileSize(convertRawProp(context, rawProps, "tileSize", sourceProps.tileSize, {256})),
+    urlTemplate(convertRawProp(context, rawProps, "urlTemplate", sourceProps.urlTemplate, {}))
+      {}
+RNMapsWMSTileProps::RNMapsWMSTileProps(
+    const PropsParserContext &context,
+    const RNMapsWMSTileProps &sourceProps,
+    const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
+
+    maximumNativeZ(convertRawProp(context, rawProps, "maximumNativeZ", sourceProps.maximumNativeZ, {100})),
+    maximumZ(convertRawProp(context, rawProps, "maximumZ", sourceProps.maximumZ, {100})),
+    minimumZ(convertRawProp(context, rawProps, "minimumZ", sourceProps.minimumZ, {0})),
+    offlineMode(convertRawProp(context, rawProps, "offlineMode", sourceProps.offlineMode, {false})),
+    shouldReplaceMapContent(convertRawProp(context, rawProps, "shouldReplaceMapContent", sourceProps.shouldReplaceMapContent, {false})),
+    tileCacheMaxAge(convertRawProp(context, rawProps, "tileCacheMaxAge", sourceProps.tileCacheMaxAge, {0})),
+    tileCachePath(convertRawProp(context, rawProps, "tileCachePath", sourceProps.tileCachePath, {})),
+    tileSize(convertRawProp(context, rawProps, "tileSize", sourceProps.tileSize, {256})),
+    urlTemplate(convertRawProp(context, rawProps, "urlTemplate", sourceProps.urlTemplate, {}))
       {}
 
 } // namespace facebook::react

--- a/ios/generated/RNMapsSpecs/Props.h
+++ b/ios/generated/RNMapsSpecs/Props.h
@@ -368,7 +368,7 @@ class RNMapsGoogleMapViewProps final : public ViewProps {
   RNMapsGoogleMapViewCameraStruct camera{};
   RNMapsGoogleMapViewInitialCameraStruct initialCamera{};
   RNMapsGoogleMapViewInitialRegionStruct initialRegion{};
-  std::string kmlSrc{};
+  std::vector<std::string> kmlSrc{};
   std::string googleMapId{};
   SharedColor loadingBackgroundColor{};
   RNMapsGoogleMapViewMapPaddingStruct mapPadding{};
@@ -886,7 +886,7 @@ class RNMapsMapViewProps final : public ViewProps {
   bool poiClickEnabled{false};
   RNMapsMapViewInitialCameraStruct initialCamera{};
   RNMapsMapViewInitialRegionStruct initialRegion{};
-  std::string kmlSrc{};
+  std::vector<std::string> kmlSrc{};
   RNMapsMapViewLegalLabelInsetsStruct legalLabelInsets{};
   bool liteMode{false};
   std::string googleMapId{};
@@ -918,6 +918,7 @@ class RNMapsMapViewProps final : public ViewProps {
   SharedColor tintColor{};
   bool toolbarEnabled{true};
   RNMapsMapViewUserInterfaceStyle userInterfaceStyle{RNMapsMapViewUserInterfaceStyle::System};
+  std::string customMapStyleString{};
   std::string userLocationAnnotationTitle{};
   bool userLocationCalloutEnabled{false};
   int userLocationFastestInterval{5000};
@@ -1093,12 +1094,12 @@ class RNMapsMarkerProps final : public ViewProps {
   bool useLegacyPinView{false};
 };
 
-struct RNMapsOverlayBoundsStruct {
+struct RNMapsOverlayBoundsNorthEastStruct {
   double latitude{0.0};
   double longitude{0.0};
 };
 
-static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, RNMapsOverlayBoundsStruct &result) {
+static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, RNMapsOverlayBoundsNorthEastStruct &result) {
   auto map = (std::unordered_map<std::string, RawValue>)value;
 
   auto tmp_latitude = map.find("latitude");
@@ -1111,19 +1112,53 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
   }
 }
 
-static inline std::string toString(const RNMapsOverlayBoundsStruct &value) {
-  return "[Object RNMapsOverlayBoundsStruct]";
+static inline std::string toString(const RNMapsOverlayBoundsNorthEastStruct &value) {
+  return "[Object RNMapsOverlayBoundsNorthEastStruct]";
 }
 
-static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, std::vector<RNMapsOverlayBoundsStruct> &result) {
-  auto items = (std::vector<RawValue>)value;
-  for (const auto &item : items) {
-    RNMapsOverlayBoundsStruct newItem;
-    fromRawValue(context, item, newItem);
-    result.emplace_back(newItem);
+struct RNMapsOverlayBoundsSouthWestStruct {
+  double latitude{0.0};
+  double longitude{0.0};
+};
+
+static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, RNMapsOverlayBoundsSouthWestStruct &result) {
+  auto map = (std::unordered_map<std::string, RawValue>)value;
+
+  auto tmp_latitude = map.find("latitude");
+  if (tmp_latitude != map.end()) {
+    fromRawValue(context, tmp_latitude->second, result.latitude);
+  }
+  auto tmp_longitude = map.find("longitude");
+  if (tmp_longitude != map.end()) {
+    fromRawValue(context, tmp_longitude->second, result.longitude);
   }
 }
 
+static inline std::string toString(const RNMapsOverlayBoundsSouthWestStruct &value) {
+  return "[Object RNMapsOverlayBoundsSouthWestStruct]";
+}
+
+struct RNMapsOverlayBoundsStruct {
+  RNMapsOverlayBoundsNorthEastStruct northEast{};
+  RNMapsOverlayBoundsSouthWestStruct southWest{};
+};
+
+static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, RNMapsOverlayBoundsStruct &result) {
+  auto map = (std::unordered_map<std::string, RawValue>)value;
+
+  auto tmp_northEast = map.find("northEast");
+  if (tmp_northEast != map.end()) {
+    fromRawValue(context, tmp_northEast->second, result.northEast);
+  }
+  auto tmp_southWest = map.find("southWest");
+  if (tmp_southWest != map.end()) {
+    fromRawValue(context, tmp_southWest->second, result.southWest);
+  }
+}
+
+static inline std::string toString(const RNMapsOverlayBoundsStruct &value) {
+  return "[Object RNMapsOverlayBoundsStruct]";
+}
 class RNMapsOverlayProps final : public ViewProps {
  public:
   RNMapsOverlayProps() = default;
@@ -1132,7 +1167,7 @@ class RNMapsOverlayProps final : public ViewProps {
 #pragma mark - Props
 
   Float bearing{0.0};
-  std::vector<RNMapsOverlayBoundsStruct> bounds{};
+  RNMapsOverlayBoundsStruct bounds{};
   ImageSource image{};
   Float opacity{1.0};
   bool tappable{false};
@@ -1219,6 +1254,44 @@ class RNMapsPolylineProps final : public ViewProps {
   std::vector<SharedColor> strokeColors{};
   Float strokeWidth{0.0};
   bool tappable{false};
+};
+
+class RNMapsUrlTileProps final : public ViewProps {
+ public:
+  RNMapsUrlTileProps() = default;
+  RNMapsUrlTileProps(const PropsParserContext& context, const RNMapsUrlTileProps &sourceProps, const RawProps &rawProps);
+
+#pragma mark - Props
+
+  bool doubleTileSize{false};
+  bool flipY{false};
+  int maximumNativeZ{100};
+  int maximumZ{100};
+  int minimumZ{0};
+  bool offlineMode{false};
+  bool shouldReplaceMapContent{false};
+  int tileCacheMaxAge{0};
+  std::string tileCachePath{};
+  int tileSize{256};
+  std::string urlTemplate{};
+};
+
+class RNMapsWMSTileProps final : public ViewProps {
+ public:
+  RNMapsWMSTileProps() = default;
+  RNMapsWMSTileProps(const PropsParserContext& context, const RNMapsWMSTileProps &sourceProps, const RawProps &rawProps);
+
+#pragma mark - Props
+
+  int maximumNativeZ{100};
+  int maximumZ{100};
+  int minimumZ{0};
+  bool offlineMode{false};
+  bool shouldReplaceMapContent{false};
+  int tileCacheMaxAge{0};
+  std::string tileCachePath{};
+  int tileSize{256};
+  std::string urlTemplate{};
 };
 
 } // namespace facebook::react

--- a/ios/generated/RNMapsSpecs/ShadowNodes.cpp
+++ b/ios/generated/RNMapsSpecs/ShadowNodes.cpp
@@ -20,5 +20,7 @@ extern const char RNMapsMapViewComponentName[] = "RNMapsMapView";
 extern const char RNMapsMarkerComponentName[] = "RNMapsMarker";
 extern const char RNMapsOverlayComponentName[] = "RNMapsOverlay";
 extern const char RNMapsPolylineComponentName[] = "RNMapsPolyline";
+extern const char RNMapsUrlTileComponentName[] = "RNMapsUrlTile";
+extern const char RNMapsWMSTileComponentName[] = "RNMapsWMSTile";
 
 } // namespace facebook::react

--- a/ios/generated/RNMapsSpecs/ShadowNodes.h
+++ b/ios/generated/RNMapsSpecs/ShadowNodes.h
@@ -106,4 +106,26 @@ using RNMapsPolylineShadowNode = ConcreteViewShadowNode<
     RNMapsPolylineEventEmitter,
     RNMapsPolylineState>;
 
+JSI_EXPORT extern const char RNMapsUrlTileComponentName[];
+
+/*
+ * `ShadowNode` for <RNMapsUrlTile> component.
+ */
+using RNMapsUrlTileShadowNode = ConcreteViewShadowNode<
+    RNMapsUrlTileComponentName,
+    RNMapsUrlTileProps,
+    RNMapsUrlTileEventEmitter,
+    RNMapsUrlTileState>;
+
+JSI_EXPORT extern const char RNMapsWMSTileComponentName[];
+
+/*
+ * `ShadowNode` for <RNMapsWMSTile> component.
+ */
+using RNMapsWMSTileShadowNode = ConcreteViewShadowNode<
+    RNMapsWMSTileComponentName,
+    RNMapsWMSTileProps,
+    RNMapsWMSTileEventEmitter,
+    RNMapsWMSTileState>;
+
 } // namespace facebook::react

--- a/ios/generated/RNMapsSpecs/States.h
+++ b/ios/generated/RNMapsSpecs/States.h
@@ -110,4 +110,28 @@ public:
 #endif
 };
 
+class RNMapsUrlTileState {
+public:
+  RNMapsUrlTileState() = default;
+
+#ifdef ANDROID
+  RNMapsUrlTileState(RNMapsUrlTileState const &previousState, folly::dynamic data){};
+  folly::dynamic getDynamic() const {
+    return {};
+  };
+#endif
+};
+
+class RNMapsWMSTileState {
+public:
+  RNMapsWMSTileState() = default;
+
+#ifdef ANDROID
+  RNMapsWMSTileState(RNMapsWMSTileState const &previousState, folly::dynamic data){};
+  folly::dynamic getDynamic() const {
+    return {};
+  };
+#endif
+};
+
 } // namespace facebook::react

--- a/react-native-maps.podspec
+++ b/react-native-maps.podspec
@@ -113,6 +113,7 @@ Pod::Spec.new do |s|
     ss.dependency 'Google-Maps-iOS-Utils', '6.1.0'
     ss.dependency 'react-native-maps/Generated'
     ss.dependency 'react-native-maps/Maps'
+    s.dependency 'SSZipArchive'
     install_modules_dependencies(ss)
   end
 

--- a/src/MapView.tsx
+++ b/src/MapView.tsx
@@ -172,7 +172,7 @@ export type MapViewProps = ViewProps & {
    * @platform iOS: Google Maps only
    * @platform Android: Supported
    */
-  kmlSrc?: string;
+  kmlSrc?: Array<string> | string;
 
   /**
    * If set, changes the position of the "Legal" label link in Apple Maps.
@@ -730,6 +730,7 @@ type ModifiedProps = Modify<
   {
     region?: MapViewProps['region'] | null;
     initialRegion?: MapViewProps['initialRegion'] | null;
+    kmlSrc?: Exclude<MapViewProps['kmlSrc'], string>;
   }
 >;
 
@@ -1140,6 +1141,7 @@ class MapView extends React.Component<MapViewProps, State> {
       provider,
       children,
       customMapStyle,
+      kmlSrc,
       ...restProps
     } = this.props;
 
@@ -1170,6 +1172,7 @@ class MapView extends React.Component<MapViewProps, State> {
       // @ts-ignore
       onIndoorLevelActivated: this.handleIndoorLevelActivated,
       onLongPress: this.handleLongPress,
+      kmlSrc: typeof kmlSrc === 'string' ? [kmlSrc] : kmlSrc,
       ...restProps,
     };
     if (this.props.region) {

--- a/src/specs/NativeComponentGoogleMapView.ts
+++ b/src/specs/NativeComponentGoogleMapView.ts
@@ -394,7 +394,7 @@ export interface MapFabricNativeProps extends ViewProps {
    * @platform iOS: Google Maps only
    * @platform Android: Supported
    */
-  kmlSrc?: string;
+  kmlSrc?: Array<string>;
 
   /**
    * https://developers.google.com/maps/documentation/get-map-id

--- a/src/specs/NativeComponentMapView.ts
+++ b/src/specs/NativeComponentMapView.ts
@@ -454,7 +454,7 @@ export interface MapFabricNativeProps extends ViewProps {
    * @platform iOS: Google Maps only
    * @platform Android: Supported
    */
-  kmlSrc?: string;
+  kmlSrc?: Array<string>;
 
   /**
    * If set, changes the position of the "Legal" label link in Apple Maps.


### PR DESCRIPTION
<!--
PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.

**What happens if you SKIP this step?**

Your pull request will NOT be evaluated!

PLEASE NOTE THAT PRs WITHOUT THE TEMPLATE IN PLACE WILL BE CLOSED RIGHT FROM THE START.

Thanks for helping us help you!
-->



https://github.com/user-attachments/assets/b3acdfd7-a42a-4f39-ac9d-d741b9f1cdf4

### Does any other open PR do the same thing?

NO


### What issue is this PR fixing?

Currently, KML and KMZ are not really well supported.
AFAIK kml supported has been introduced in 2018 by this PR: https://github.com/react-native-maps/react-native-maps/pull/2011 but it only added support for markers, and not complete KML file, and it was done "by hand" (iterating over the placemarks and adding a marker on the map).

Since then, Google's [android-maps-utils](https://github.com/googlemaps/android-maps-utils) and [ios-map-utils](https://github.com/googlemaps/google-maps-ios-utils) have both added kml support. (android support is ahead of iOS concerning kmz). So, we don't need to do it "by hand" anymore, we can use the maps-utils to parse en render a KML file directly.

This Pull request add support for:
 - iOS: wider KML support (polyline, polygon, and markers) with the correct styling (android was already working)
 - iOS: support for KMZ ( zipped kml ) to support custom marker image embedded directly in the kmz. (android was already working)
 - iOS: use default KML callout. (android was already working)
 - Android and IOS: multiple KML source at once
 - Update example kml page

### Breaking change:
Currently, when onKmlReady is dispatched, we add a parameter with the list of markers that have been drawn.
I think this is a weird “contract” / “API” that makes little to no sense, and is probably too tightly coupled to a very specific need, but we can discuss it.
My opinion is that if you want access to all markers, polylines, polygons, etc. that have been drawn, it means you should probably parse your KML on the JS side and add them yourself.
If we send the list of markers that have been added, we should also send polygons, polyline, their style etc … ? At this point why not just parse the kml on the js side
 
 
 ### About the KMZ part
 I use the **SSZipArchive** library to unzip the KMZ, it adds a new dependency to the project. Ideally it should be done by Google's iOS utils, I hope in the future we can remove my implementation, but for now map-utils does not implement it. (Android version does)


### How did you test this PR?
Mostly using the dedicated KML example


