### PR TITLE
fix: ts-import for decorateMapComponent

### DIFF
--- a/src/decorateMapComponent.ts
+++ b/src/decorateMapComponent.ts
@@ -23,7 +23,7 @@ import {Commands} from './MapViewNativeComponent';
 import GooglePolygon from './specs/NativeComponentGooglePolygon';
 import FabricMarker from './specs/NativeComponentMarker';
 import FabricUrlTile from './specs/NativeComponentUrlTile';
-import FabricWMSTile from './specs/NativeComponentWMSTile.ts';
+import FabricWMSTile from './specs/NativeComponentWMSTile';
 import FabricCallout from './specs/NativeComponentCallout';
 import FabricPolyline from './specs/NativeComponentPolyline';
 import FabricCircle from './specs/NativeComponentCircle';


### PR DESCRIPTION


### Does any other open PR do the same thing?

Yes, https://github.com/react-native-maps/react-native-maps/pull/5465

### What issue is this PR fixing?

Fixes the TypeScript errors:

../../node_modules/react-native-maps/src/decorateMapComponent.ts:26:27 - error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
https://github.com/react-native-maps/react-native-maps/issues/5423

### How did you test this PR?

