### PR TITLE
fix: correctly emit marker-press event for Android

### DIFF
--- a/android/src/main/java/com/rnmaps/maps/MapView.java
+++ b/android/src/main/java/com/rnmaps/maps/MapView.java
@@ -459,7 +459,7 @@ public class MapView extends com.google.android.gms.maps.MapView implements Goog
                 MapMarker airMapMarker = getMarkerMap(marker);
 
                 WritableMap eventData = makeClickEventData(marker.getPosition());
-                eventData.putString("action", "press");
+                eventData.putString("action", "marker-press");
                 eventData.putString("id", airMapMarker.getIdentifier());
                 airMapMarker.dispatchEvent(eventData, OnPressEvent::new);
 


### PR DESCRIPTION
### Does any other open PR do the same thing?

There is no other open PR doing the same thing.

### What issue is this PR fixing?

https://github.com/react-native-maps/react-native-maps/issues/5513

### How did you test this PR?

I have created a patch for the package with this change in my own project and it fixed the issue I was encountering. The issue also links to a commit that was made for the rewrite for Fabric where these lines were apparently incorrectly changed.
