### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,57 +214,6 @@ For Android: add the following line in your AndroidManifest.xml
 
 For IOS: configure [App Transport Security](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW33) in your app
 
-## React Native Configuration for Fabric / New Architecture
-
-This library doesn't support the new arch yet due to issues with inserting subviews / interoplayer. we're working on it.
-
-### Configuration Steps
-
-1. **Open your configuration file**: Locate the `react-native-config` file in your project directory.
-
-2. **Add the following configuration**: Include the `unstable_reactLegacyComponentNames` array for both Android and iOS platforms as shown below:
-
-```javascript
-module.exports = {
-  project: {
-    android: {
-      unstable_reactLegacyComponentNames: [
-        'AIRMap',
-        'AIRMapCallout',
-        'AIRMapCalloutSubview',
-        'AIRMapCircle',
-        'AIRMapHeatmap',
-        'AIRMapLocalTile',
-        'AIRMapMarker',
-        'AIRMapOverlay',
-        'AIRMapPolygon',
-        'AIRMapPolyline',
-        'AIRMapUrlTile',
-        'AIRMapWMSTile',
-      ],
-    },
-    ios: {
-      unstable_reactLegacyComponentNames: [
-        'AIRMap',
-        'AIRMapCallout',
-        'AIRMapCalloutSubview',
-        'AIRMapCircle',
-        'AIRMapHeatmap',
-        'AIRMapLocalTile',
-        'AIRMapMarker',
-        'AIRMapOverlay',
-        'AIRMapPolygon',
-        'AIRMapPolyline',
-        'AIRMapUrlTile',
-        'AIRMapWMSTile',
-      ],
-    },
-  },
-};
-```
-
-checkout the example project to see it in action.
-
 #### Tile Overlay using local tiles
 
 Tiles can be stored locally within device using xyz tiling scheme and displayed as tile overlay as well. This is usefull especially for offline map usage when tiles are available for selected map region within device storage.


### PR DESCRIPTION
Remove the part for `unstable_reactLegacyComponentNames` as it was removed with 1.19.1 see https://github.com/react-native-maps/react-native-maps/pull/5209#issuecomment-2498390067 and https://github.com/react-native-maps/react-native-maps/compare/v1.19.0...v1.19.1