### PR TITLE
fix: react ref element type deprecation fix

### DIFF
--- a/src/createFabricMap.tsx
+++ b/src/createFabricMap.tsx
@@ -45,7 +45,7 @@ export interface FabricMapHandle {
 const createFabricMap = (ViewComponent: React.ComponentType, Commands: any) => {
   return forwardRef<FabricMapHandle | null, FabricMapViewProps>(
     (props, ref) => {
-      const fabricRef = useRef<React.ElementRef<typeof ViewComponent>>(null);
+      const fabricRef = useRef<React.Component>(null);
 
       useImperativeHandle(ref, () => ({
         async getMarkersFrames(onlyVisible: boolean) {

--- a/src/specs/NativeComponentGoogleMapView.ts
+++ b/src/specs/NativeComponentGoogleMapView.ts
@@ -861,43 +861,43 @@ export interface MapFabricNativeProps extends ViewProps {
 
 export interface NativeCommands {
   animateToRegion: (
-    viewRef: React.ElementRef<React.ComponentType>,
+    viewRef: React.RefObject<React.ComponentType>,
     regionJSON: string,
     duration: Int32,
   ) => void;
 
   setCamera: (
-    viewRef: React.ElementRef<React.ComponentType>,
+    viewRef: React.RefObject<React.ComponentType>,
     cameraJSON: string,
   ) => void;
 
   animateCamera: (
-    viewRef: React.ElementRef<React.ComponentType>,
+    viewRef: React.RefObject<React.ComponentType>,
     cameraJSON: string,
     duration: Int32,
   ) => void;
 
   fitToElements: (
-    viewRef: React.ElementRef<React.ComponentType>,
+    viewRef: React.RefObject<React.ComponentType>,
     edgePaddingJSON: string,
     animated: boolean,
   ) => void;
 
   fitToSuppliedMarkers: (
-    viewRef: React.ElementRef<React.ComponentType>,
+    viewRef: React.RefObject<React.ComponentType>,
     markersJSON: string,
     edgePaddingJSON: string,
     animated: boolean,
   ) => void;
 
   fitToCoordinates: (
-    viewRef: React.ElementRef<React.ComponentType>,
+    viewRef: React.RefObject<React.ComponentType>,
     coordinatesJSON: string,
     edgePaddingJSON: string,
     animated: boolean,
   ) => void;
   setIndoorActiveLevelIndex: (
-    viewRef: React.ElementRef<React.ComponentType>,
+    viewRef: React.RefObject<React.ComponentType>,
     activeLevelIndex: Int32,
   ) => void;
 }

--- a/src/specs/NativeComponentMapView.ts
+++ b/src/specs/NativeComponentMapView.ts
@@ -1040,44 +1040,44 @@ export interface MapFabricNativeProps extends ViewProps {
 
 export interface NativeCommands {
   animateToRegion: (
-    viewRef: React.ElementRef<React.ComponentType>,
+    viewRef: React.RefObject<React.ComponentType>,
     regionJSON: string,
     duration: Int32,
   ) => void;
 
   setCamera: (
-    viewRef: React.ElementRef<React.ComponentType>,
+    viewRef: React.RefObject<React.ComponentType>,
     cameraJSON: string,
   ) => void;
 
   animateCamera: (
-    viewRef: React.ElementRef<React.ComponentType>,
+    viewRef: React.RefObject<React.ComponentType>,
     cameraJSON: string,
     duration: Int32,
   ) => void;
 
   fitToElements: (
-    viewRef: React.ElementRef<React.ComponentType>,
+    viewRef: React.RefObject<React.ComponentType>,
     edgePaddingJSON: string,
     animated: boolean,
   ) => void;
 
   fitToSuppliedMarkers: (
-    viewRef: React.ElementRef<React.ComponentType>,
+    viewRef: React.RefObject<React.ComponentType>,
     markersJSON: string,
     edgePaddingJSON: string,
     animated: boolean,
   ) => void;
 
   fitToCoordinates: (
-    viewRef: React.ElementRef<React.ComponentType>,
+    viewRef: React.RefObject<React.ComponentType>,
     coordinatesJSON: string,
     edgePaddingJSON: string,
     animated: boolean,
   ) => void;
 
   setIndoorActiveLevelIndex: (
-    viewRef: React.ElementRef<React.ComponentType>,
+    viewRef: React.RefObject<React.ComponentType>,
     activeLevelIndex: Int32,
   ) => void;
 }

--- a/src/specs/NativeComponentMarker.ts
+++ b/src/specs/NativeComponentMarker.ts
@@ -293,20 +293,20 @@ export interface MarkerFabricNativeProps extends ViewProps {
 }
 export interface NativeCommands {
   animateToCoordinates: (
-    viewRef: React.ElementRef<React.ComponentType>,
+    viewRef: React.RefObject<React.ComponentType>,
     latitude: Double,
     longitude: Double,
     duration: Int32,
   ) => void;
   setCoordinates: (
-    viewRef: React.ElementRef<React.ComponentType>,
+    viewRef: React.RefObject<React.ComponentType>,
     latitude: Double,
     longitude: Double,
   ) => void;
-  showCallout: (viewRef: React.ElementRef<React.ComponentType>) => void;
-  hideCallout: (viewRef: React.ElementRef<React.ComponentType>) => void;
-  redrawCallout: (viewRef: React.ElementRef<React.ComponentType>) => void;
-  redraw: (viewRef: React.ElementRef<React.ComponentType>) => void;
+  showCallout: (viewRef: React.RefObject<React.ComponentType>) => void;
+  hideCallout: (viewRef: React.RefObject<React.ComponentType>) => void;
+  redrawCallout: (viewRef: React.RefObject<React.ComponentType>) => void;
+  redraw: (viewRef: React.RefObject<React.ComponentType>) => void;
 }
 
 export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({


### PR DESCRIPTION
### What issue is this PR fixing?

https://github.com/react-native-maps/react-native-maps/issues/5492

### How did you test this PR?

<img width="645" alt="Screenshot 2025-05-27 at 10 28 07" src="https://github.com/user-attachments/assets/0266eeef-de50-4c73-b76c-1309dcdbc2c2" />

The changes were only affecting typescript types so no functionality was altered.
