### PR TITLE
fix(ios): googleMaps marker images not visible

### DIFF
--- a/src/MapMarker.tsx
+++ b/src/MapMarker.tsx
@@ -481,13 +481,29 @@ export class MapMarker extends React.Component<MapMarkerProps> {
       );
     }
 
-    let icon;
-    if (this.props.icon && this.fabricMarker) {
-      icon = fixImageProp(this.props.icon);
-    }
-    let image;
-    if (this.props.image && this.fabricMarker) {
-      image = fixImageProp(this.props.image);
+    let icon: any = this.props.icon;
+    let image: any = this.props.image;
+
+    if (this.fabricMarker) {
+      if (this.props.image) {
+        image = fixImageProp(this.props.image);
+      }
+      if (this.props.icon) {
+        icon = fixImageProp(this.props.icon);
+      }
+    } else {
+      if (this.props.image) {
+        image = fixImageProp(this.props.image);
+        if (image.uri) {
+          image = image.uri;
+        }
+      }
+      if (this.props.icon) {
+        icon = fixImageProp(this.props.icon);
+        if (icon.uri) {
+          icon = icon.uri;
+        }
+      }
     }
 
     const AIRMapMarker = this.getNativeComponent();


### PR DESCRIPTION


### Does any other open PR do the same thing?

No


### What issue is this PR fixing?

https://github.com/react-native-maps/react-native-maps/issues/5443

### How did you test this PR?
example project with all variation of provider (ios, ios-google, android)

