### PR TITLE
fix: Array<never> in AnimatedRegion.ts

### DIFF
--- a/src/AnimatedRegion.ts
+++ b/src/AnimatedRegion.ts
@@ -136,7 +136,7 @@ export default class AnimatedMapRegion extends AnimatedWithChildren {
   }
 
   spring(config: Animated.SpringAnimationConfig & Region) {
-    const animations = [];
+    const animations: Array<Animated.CompositeAnimation> = [];
     for (const type of configTypes) {
       if (config.hasOwnProperty(type)) {
         animations.push(
@@ -153,7 +153,7 @@ export default class AnimatedMapRegion extends AnimatedWithChildren {
   }
 
   timing(config: Animated.TimingAnimationConfig & Region) {
-    const animations = [];
+    const animations: Array<Animated.CompositeAnimation> = [];
     for (const type of configTypes) {
       if (config.hasOwnProperty(type)) {
         animations.push(


### PR DESCRIPTION
Fix following type-error.
```
[16:59:23] File change detected. Starting incremental compilation...

node_modules/react-native-maps/src/AnimatedRegion.ts:143:11 - error TS2345: Argument of type 'CompositeAnimation' is not assignable to parameter of type 'never'.

143           Animated.spring(this[type], {
              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
144             ...config,
    ~~~~~~~~~~~~~~~~~~~~~~
...
147             useNativeDriver: !!config?.useNativeDriver,
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
148           }),
    ~~~~~~~~~~~~

node_modules/react-native-maps/src/AnimatedRegion.ts:159:25 - error TS2345: Argument of type 'CompositeAnimation' is not assignable to parameter of type 'never'.

159         animations.push(Animated.timing(this[type], {
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
160           ...config,
    ~~~~~~~~~~~~~~~~~~~~
...
163           useNativeDriver: !!config?.useNativeDriver,
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
164         }));
    ~~~~~~~~~~

[16:59:23] Found 2 errors. Watching for file changes.
```

### Does any other open PR do the same thing?
No (skimmed open PR's)

### What issue is this PR fixing?
Add explicit type to `const` declaration since it can implicitly be `Array<never>` / `never[]`

### How did you test this PR?
Had a typescript watching running (with the error) and just modified the code in node_modules and it was fixed.