### PR TITLE
Add typescript type info for showsTraffic property in MapView.tsx

### DIFF
--- a/src/MapView.tsx
+++ b/src/MapView.tsx
@@ -597,6 +597,15 @@ export type MapViewProps = ViewProps & {
   showsScale?: boolean;
 
   /**
+   * A Boolean value indicating whether the map displays traffic information. 
+   *
+   * @default false
+   * @platform iOS: Supported
+   * @platform Android: Supported
+   */
+  showsTraffic?: boolean;
+
+  /**
    * If `true` the users location will be displayed on the map.
    *
    * This will cause iOS to ask for location permissions.


### PR DESCRIPTION
### Does any other open PR do the same thing?

<!--
**Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**

If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)
 -->

Not that I could find.

### What issue is this PR fixing?

Typescript type information for `showsTraffic` property on `MapView`.

### How did you test this PR?
I've not tested this, but I noticed a discrepancy between the documentation for the `<MapView/>`-api (https://github.com/react-native-maps/react-native-maps/blob/5873c0cd8aaac04e08cf29bf30762cadc54379d6/docs/mapview.md?plain=1#L31) and the actual `MapViewProps` in typescript.

I'm unsure if the properties get passed somehow to lower level components or api's, but the documentation states that there is a property however it does not exist in the typescript type definition. This PR adds that property info, perhaps it should instead be removed from documentation?
