### PR TITLE
fix: re-order prop / feature color / stroke width selection

### DIFF
--- a/src/Geojson.tsx
+++ b/src/Geojson.tsx
@@ -450,8 +450,7 @@ const getColor = (
     }
 
     return color;
-  }
-  else if (prop) {
+  } else if (prop) {
     return prop;
   }
 


### PR DESCRIPTION
### Does any other open PR do the same thing?

There's no existing PR for this.

### What issue is this PR fixing?

Fixes #3385. When styles are supplied to the `<Geojson>` component props itself as well as individual features (e.g. styling features in different ways based on some status or value), the component props always win.

### How did you test this PR?

I tested the PR by applying a patch locally (using `patch-package`) and ran it on an Android emulator.