### PR TITLE
fix(android): restore lifecycle observer registration in constructor

### DIFF
--- a/android/src/main/java/com/rnmaps/maps/MapView.java
+++ b/android/src/main/java/com/rnmaps/maps/MapView.java
@@ -255,6 +255,8 @@ public class MapView extends com.google.android.gms.maps.MapView implements Goog
         this.context = context;
         super.getMapAsync(this);
 
+        attachLifecycleObserver();
+
         final MapView view = this;
 
         fusedLocationSource = new FusedLocationSource(context);
@@ -288,7 +290,6 @@ public class MapView extends com.google.android.gms.maps.MapView implements Goog
             }
         });
 
-
         // Set up a parent view for triggering visibility in subviews that depend on it.
         // Mainly ReactImageView depends on Fresco which depends on onVisibilityChanged() event
         attacherGroup = new ViewAttacherGroup(context);
@@ -306,19 +307,6 @@ public class MapView extends com.google.android.gms.maps.MapView implements Goog
                    GoogleMapOptions googleMapOptions) {
         this(null, googleMapOptions);
 
-    }
-
-    @Override
-    protected void onAttachedToWindow() {
-        super.onAttachedToWindow();
-        attachLifecycleObserver();
-    }
-
-    // Override onDetachedFromWindow to detach lifecycle observer
-    @Override
-    protected void onDetachedFromWindow() {
-        detachLifecycleObserver();
-        super.onDetachedFromWindow();
     }
 
     // Method to attach lifecycle observer


### PR DESCRIPTION
### Does any other open PR do the same thing?

No, I have not found any other open PR addressing this specific regression with the Android map lifecycle observer.

### What issue is this PR fixing?

This PR fixes #5595 and a regression introduced in v1.24.3 (commit ae8d38c672e1671ea53f28336b11fbbb139e861f) where the map on Android would stop working after navigating away and back to the screen. Symptoms included the region resetting, markers disappearing, and events no longer firing. The regression was caused by moving lifecycle observer registration from the constructor to onAttachedToWindow/onDetachedFromWindow.

### How did you test this PR?

I tested this fix by creating a Stack Navigator in App.tsx with two screens: MapScreen (showing the map) and DetailScreen. On DetailScreen, I tested navigating back to the map using:

navigation.goBack()
navigation.popToTop()
The default back button in the header

I tested with Pixel 6 Pro API 34 (Emulator) on a MacBook Pro M1.
