### PR TITLE
chore(android): remove legacy compatibility classes for minSdk 21+

### DIFF
--- a/android/src/main/java/com/rnmaps/maps/MapView.java
+++ b/android/src/main/java/com/rnmaps/maps/MapView.java
@@ -24,8 +24,6 @@ import android.widget.RelativeLayout;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.content.PermissionChecker;
-import androidx.core.view.GestureDetectorCompat;
-import androidx.core.view.MotionEventCompat;
 
 import com.facebook.react.common.MapBuilder;
 
@@ -145,7 +143,7 @@ public class MapView extends com.google.android.gms.maps.MapView implements Goog
     private final Map<GroundOverlay, MapOverlay> overlayMap = new HashMap<>();
     private final Map<TileOverlay, MapHeatmap> heatmapMap = new HashMap<>();
     private final Map<TileOverlay, MapGradientPolyline> gradientPolylineMap = new HashMap<>();
-    private final GestureDetectorCompat gestureDetector;
+    private final GestureDetector gestureDetector;
     private boolean paused = false;
     private boolean destroyed = false;
     private final ThemedReactContext context;
@@ -260,7 +258,7 @@ public class MapView extends com.google.android.gms.maps.MapView implements Goog
         fusedLocationSource = new FusedLocationSource(context);
 
         gestureDetector =
-                new GestureDetectorCompat(context, new GestureDetector.SimpleOnGestureListener() {
+                new GestureDetector(context, new GestureDetector.SimpleOnGestureListener() {
 
                     @Override
                     public boolean onScroll(MotionEvent e1, MotionEvent e2, float distanceX,
@@ -1519,7 +1517,7 @@ public class MapView extends com.google.android.gms.maps.MapView implements Goog
             tapLocation = map.getProjection().fromScreenLocation(new Point(X, Y));
         }
 
-        int action = MotionEventCompat.getActionMasked(ev);
+        int action = ev.getActionMasked();
 
         switch (action) {
             case (MotionEvent.ACTION_DOWN):


### PR DESCRIPTION
### Does any other open PR do the same thing?
No

### What issue is this PR fixing?
remove legacy compatibility classes for minSdk 21+
(please link the issue here)

### How did you test this PR?

tested with the example app on android emulator