### PR TITLE
fix(android): fix NPE crash on destroy

### DIFF
--- a/android/src/main/java/com/rnmaps/fabric/MapViewManager.java
+++ b/android/src/main/java/com/rnmaps/fabric/MapViewManager.java
@@ -618,6 +618,6 @@ public class MapViewManager extends ViewGroupManager<MapView> implements RNMapsM
     @Override
     public void onDropViewInstance(MapView view) {
         super.onDropViewInstance(view);
-        view.onDestroy();
+        view.doDestroy();
     }
 }


### PR DESCRIPTION


### Does any other open PR do the same thing?

No


### What issue is this PR fixing?

https://github.com/react-native-maps/react-native-maps/issues/5578

### How did you test this PR?
couldn't reproduce the crash but the logic is consistent, naked use of onDestroy causes NPE while use of the safe method doDestroy (checks for observers) solved other NPE caused by lifecycle before.



