### PR TITLE
fix: guard against null parent in removeMapLoadingLayoutView 

### DIFF
--- a/android/src/main/java/com/rnmaps/maps/MapView.java
+++ b/android/src/main/java/com/rnmaps/maps/MapView.java
@@ -18,6 +18,7 @@ import android.view.GestureDetector;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.ViewParent;
 import android.widget.ImageView;
 import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
@@ -1639,14 +1640,20 @@ public class MapView extends com.google.android.gms.maps.MapView implements Goog
 
     private void removeCacheImageView() {
         if (this.cacheImageView != null) {
-            ((ViewGroup) this.cacheImageView.getParent()).removeView(this.cacheImageView);
+            ViewParent parent = this.cacheImageView.getParent();
+            if (parent instanceof ViewGroup) {
+              ((ViewGroup) parent).removeView(this.cacheImageView);
+            }
             this.cacheImageView = null;
         }
     }
 
     private void removeMapLoadingProgressBar() {
         if (this.mapLoadingProgressBar != null) {
-            ((ViewGroup) this.mapLoadingProgressBar.getParent()).removeView(this.mapLoadingProgressBar);
+            ViewParent parent = this.mapLoadingProgressBar.getParent();
+            if (parent instanceof ViewGroup) {
+              ((ViewGroup) parent).removeView(this.mapLoadingProgressBar);
+            }
             this.mapLoadingProgressBar = null;
         }
     }
@@ -1654,7 +1661,10 @@ public class MapView extends com.google.android.gms.maps.MapView implements Goog
     private void removeMapLoadingLayoutView() {
         this.removeMapLoadingProgressBar();
         if (this.mapLoadingLayout != null) {
-            ((ViewGroup) this.mapLoadingLayout.getParent()).removeView(this.mapLoadingLayout);
+            ViewParent parent = this.mapLoadingLayout.getParent();
+            if (parent instanceof ViewGroup) {
+              ((ViewGroup) parent).removeView(this.mapLoadingLayout);
+            }
             this.mapLoadingLayout = null;
         }
     }

--- a/android/src/main/java/com/rnmaps/maps/MapView.java
+++ b/android/src/main/java/com/rnmaps/maps/MapView.java
@@ -1220,7 +1220,7 @@ public class MapView extends com.google.android.gms.maps.MapView implements Goog
             feature.removeFromMap(polygonCollection);
         } else if (feature instanceof MapPolyline) {
             feature.removeFromMap(polylineCollection);
-        } else {
+        } else if (feature != null) {
             feature.removeFromMap(map);
         }
     }


### PR DESCRIPTION
### Does any other open PR do the same thing?

Didn't find any

### What issue is this PR fixing?

PR Description
This patch addresses a crash in MapView.removeMapLoadingLayoutView() where mapLoadingLayout.getParent() can be null, causing a NullPointerException.

What’s changed

Added a check for `mapLoadingLayout.getParent()` != null before `calling removeView(...)`

Ensures we only remove the loading layout when it’s actually attached to a parent

Why
Under certain lifecycle or rapid toggle scenarios, the loading layout may never have been added—or may already have been detached—so calling removeView without guarding its parent leads to:

```
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 
'void android.view.ViewGroup.removeView(android.view.View)' on a null object reference
```

Stack Trace:
```
   Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'void android.view.ViewGroup.removeView(android.view.View)' on a null object reference
       at com.rnmaps.maps.MapView.removeMapLoadingLayoutView(MapView.java:1657)
       at com.rnmaps.maps.MapView.cacheView(MapView.java:1681)
       at com.rnmaps.maps.MapView.lambda$onMapReady$6(MapView.java:648)
       at com.rnmaps.maps.MapView.$r8$lambda$O9OgSxbkAXkpbgjYZLZanbqYa00()
       at com.rnmaps.maps.MapView$$ExternalSyntheticLambda30.onMapLoaded(D8$$SyntheticClass)
       at com.google.android.gms.maps.zzj.zzb(com.google.android.gms:play-services-maps@@19.1.0:1)
       at com.google.android.gms.maps.internal.zzao.zza(com.google.android.gms:play-services-maps@@19.1.0:1)
       at com.google.android.gms.internal.maps.zzb.onTransact(com.google.android.gms:play-services-maps@@19.1.0:3)
       at android.os.Binder.transact(Binder.java:1183)
       at fe.c(:com.google.android.gms.dynamite_mapsdynamite@231818047@23.18.18 (190800-0):2)
       at com.google.android.gms.maps.internal.ak.e(:com.google.android.gms.dynamite_mapsdynamite@231818047@23.18.18 (190800-0))
       at com.google.maps.api.android.lib6.impl.cn.run(:com.google.android.gms.dynamite_mapsdynamite@231818047@23.18.18 (190800-0):7)
       at android.os.Handler.handleCallback(Handler.java:958)
       at android.os.Handler.dispatchMessage(Handler.java:99)
       at android.os.Looper.loopOnce(Looper.java:205)
       at android.os.Looper.loop(Looper.java:294)
       at android.app.ActivityThread.main(ActivityThread.java:8177)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:552)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:971)
```

### How did you test this PR?

Tested and debugged on my device
