### PR TITLE
fix: NullPointerException in MapView.onDetachedFromWindow

### DIFF
--- a/android/src/main/java/com/rnmaps/maps/MapView.java
+++ b/android/src/main/java/com/rnmaps/maps/MapView.java
@@ -334,16 +334,12 @@ public class MapView extends com.google.android.gms.maps.MapView implements Goog
     // Override onDetachedFromWindow to detach lifecycle observer
     @Override
     protected void onDetachedFromWindow() {
-        if (savedMapState == null) {
-            savedMapState = new Bundle();
-        }
-        super.onSaveInstanceState(savedMapState);
-        super.onPause();
-        super.onStop();
         savedFeatures = new HashMap<>(features);
         savedFeatures.keySet().forEach(this::removeFeatureAt);
-        removeView(attacherGroup);
-        attacherGroup = null;
+        if (attacherGroup != null) {
+          removeView(attacherGroup);
+          attacherGroup = null;
+        }
         detachLifecycleObserver();
         super.onDetachedFromWindow();
     }


### PR DESCRIPTION
### Does any other open PR do the same thing?

No

### What issue is this PR fixing?

Please confirm my observation below.

We were crashing with an NPE in `onDetachedFromWindow()` because our override was still calling `super.onSaveInstanceState()`, `super.onPause()`, and `super.onStop()` even after the Google Maps internal delegate had already been torn down, leaving it null. Simply removing those calls and only cleaning up feature views and lifecycle observer before delegating to `super.onDetachedFromWindow()` fixes the issue by ensuring we never invoke the Maps delegate when it doesn’t exist.

### How did you test this PR?

Tested on my device

### Stack Trace
```
          Fatal Exception: java.lang.NullPointerException: Attempt to invoke interface method 'void com.google.maps.api.android.lib6.impl.bq.y(android.os.Bundle)' on a null object reference
       at com.google.maps.api.android.lib6.impl.cu.k(:com.google.android.gms.dynamite_mapsdynamite@231818047@23.18.18 (190800-0))
       at com.google.android.gms.maps.internal.q.bb(:com.google.android.gms.dynamite_mapsdynamite@231818047@23.18.18 (190800-0):15)
       at ff.onTransact(:com.google.android.gms.dynamite_mapsdynamite@231818047@23.18.18 (190800-0):4)
       at android.os.Binder.transact(Binder.java:1183)
       at com.google.android.gms.internal.maps.zza.zzJ(com.google.android.gms:play-services-maps@@19.1.0:2)
       at com.google.android.gms.maps.internal.zzl.onSaveInstanceState(com.google.android.gms:play-services-maps@@19.1.0:3)
       at com.google.android.gms.maps.zzah.onSaveInstanceState(com.google.android.gms:play-services-maps@@19.1.0:3)
       at com.google.android.gms.dynamic.DeferredLifecycleHelper.onSaveInstanceState(com.google.android.gms:play-services-base@@18.4.0:1)
       at com.google.android.gms.maps.MapView.onSaveInstanceState(com.google.android.gms:play-services-maps@@19.1.0:1)
       at com.rnmaps.maps.MapView.onDetachedFromWindow(MapView.java:341)
       at android.view.View.dispatchDetachedFromWindow(View.java:22040)
       at android.view.ViewGroup.dispatchDetachedFromWindow(ViewGroup.java:3984)
       at android.view.ViewGroup.clearDisappearingChildren(ViewGroup.java:7111)
       at android.view.ViewGroup.dispatchDetachedFromWindow(ViewGroup.java:3978)
       at android.view.ViewGroup.clearDisappearingChildren(ViewGroup.java:7111)
       at android.view.ViewGroup.dispatchDetachedFromWindow(ViewGroup.java:3978)
       at android.view.ViewGroup.clearDisappearingChildren(ViewGroup.java:7111)
       at android.view.ViewGroup.dispatchDetachedFromWindow(ViewGroup.java:3978)
       at android.view.ViewGroup.dispatchDetachedFromWindow(ViewGroup.java:3976)
       at android.view.ViewGroup.endViewTransition(ViewGroup.java:7222)
       at com.swmansion.rnscreens.ScreenStack.endViewTransition(ScreenStack.kt:75)
       at androidx.fragment.app.DefaultSpecialEffectsController$startAnimations$3.onAnimationEnd$lambda$0(DefaultSpecialEffectsController.kt:272)
       at androidx.fragment.app.DefaultSpecialEffectsController$startAnimations$3.$r8$lambda$ZytGaoJ8By--dVBbT6zTRvs0sIA()
       at androidx.fragment.app.DefaultSpecialEffectsController$startAnimations$3$$ExternalSyntheticLambda0.run(D8$$SyntheticClass)
       at android.os.Handler.handleCallback(Handler.java:958)
       at android.os.Handler.dispatchMessage(Handler.java:99)
       at android.os.Looper.loopOnce(Looper.java:205)
       at android.os.Looper.loop(Looper.java:294)
       at android.app.ActivityThread.main(ActivityThread.java:8177)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:552)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:971)
        
```