### PR TITLE
fix(ios): attempt to fix ci by pinning the macOS version

### DIFF
--- a/.github/workflows/iosBuild.yml
+++ b/.github/workflows/iosBuild.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build-ios:
-    runs-on: macos-latest
+    runs-on: macos-15
 
     steps:
       - name: Check out repository code

--- a/.github/workflows/iosFrameworksBuild.yml
+++ b/.github/workflows/iosFrameworksBuild.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build-ios-frameworks:
-    runs-on: macos-latest
+    runs-on: macos-15
 
     steps:
       - name: Check out repository code


### PR DESCRIPTION
Does any other open PR do the same thing?
Yes
https://github.com/react-native-maps/react-native-maps/pull/5702

I'm trying to keep change to minimum by only fixing the image version of the CI, so that we can use latest again once github release a fixed version of their action.

What issue is this PR fixing?
broken CI

How did you test this PR?
let's hope for a green iOS builds