### PR TITLE
fix: update versions for new/old arch support in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ See [Setup Instructions for the Included Example Project](docs/examples-setup.md
 
 | Version          | React Native Requirement |
 | ---------------- | ------------------------ |
-| 1.20.1 and below | >= 0.74                  |
 | 1.14.0 - 1.20.1  | >= 0.74                  |
 | < 1.14.0         | >= 0.64.3                |
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ See [Setup Instructions for the Included Example Project](docs/examples-setup.md
 
 | Version          | React Native Requirement |
 | ---------------- | ------------------------ |
-| 1.21.1 and below | >= 0.74                  |
-| 1.14.0 - 1.21.1  | >= 0.74                  |
+| 1.20.1 and below | >= 0.74                  |
+| 1.14.0 - 1.20.1  | >= 0.74                  |
 | < 1.14.0         | >= 0.64.3                |
 
 ## Component API

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ See [Setup Instructions for the Included Example Project](docs/examples-setup.md
 
 ### Old Architecture
 
-| Version          | React Native Requirement |
-| ---------------- | ------------------------ |
-| 1.14.0 - 1.20.1  | >= 0.74                  |
-| < 1.14.0         | >= 0.64.3                |
+| Version         | React Native Requirement |
+| --------------- | ------------------------ |
+| 1.14.0 - 1.20.1 | >= 0.74                  |
+| < 1.14.0        | >= 0.64.3                |
 
 ## Component API
 


### PR DESCRIPTION
<!--
PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.

**What happens if you SKIP this step?**

Your pull request will NOT be evaluated!

PLEASE NOTE THAT PRs WITHOUT THE TEMPLATE IN PLACE WILL BE CLOSED RIGHT FROM THE START.

Thanks for helping us help you!
-->

### Does any other open PR do the same thing?

No

<!--
**Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**

If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)
 -->

### What issue is this PR fixing?

The README file lists 1.21.1 as the last supported version for the old architecture.
1.21.0 is the first version with Fabric support (and where the old architecture is no longer supported).
1.20.1 is the last version where the old architecture is supported

### How did you test this PR?

<!--
Please let us know how you have verified that your changes work.

Ideally, your PR should contain a step-by-step test plan, so that reviewers can easily verify your changes.

Your PR will have much better chances of being merged if it is straightforward to verify.

Some questions you might want to think about:

- Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any?
- Did you test this on a real device, or in a simulator?
- Are there any platforms you were not able to test?
-->

N/A

<!--
Thanks for your contribution :)
-->
