### PR TITLE
Fix for marker/polyline disappearing after the first load when naviga…

### DIFF
--- a/android/src/main/java/com/rnmaps/fabric/MapViewManager.java
+++ b/android/src/main/java/com/rnmaps/fabric/MapViewManager.java
@@ -323,7 +323,7 @@ public class MapViewManager extends ViewGroupManager<MapView> implements RNMapsM
                 parent.addFeature(child, parent.getFeatureCount());
             });
         } else {
-            parent.addFeature(child, index);
+            parent.addFeature(child, parent.getFeatureCount());
         }
     }
 


### PR DESCRIPTION
Does any other open PR do the same thing?

No.
This PR fixes a specific issue where map features such as MapMarker and Polyline disappear after navigating back to a screen containing a MapView. I couldn’t find any other PR addressing this behavior.

What issue is this PR fixing?

#5750 

The fix changes the feature key assignment logic to use the current map size instead of a fixed index, ensuring each feature has a unique key and preventing overwriting.

How did you test this PR?

Tested on:

Android (Google Maps)

iOS Simulator (Apple Maps)

Steps to reproduce and verify fix:

Open a screen containing a MapView with multiple markers and/or polylines.

Navigate to another screen.

Navigate back to the map screen.

Before fix: some or all markers/polylines disappear.

After fix: all features remain visible and render correctly.

✅ Fix summary: Prevent map features from disappearing when navigating back by using map size instead of fixed index for hash map keys.