### PR TITLE
fix(android): fix crash when getFeatureAt larger than index

### DIFF
--- a/android/src/main/java/com/rnmaps/fabric/MapViewManager.java
+++ b/android/src/main/java/com/rnmaps/fabric/MapViewManager.java
@@ -35,11 +35,9 @@ import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.LatLngBounds;
 import com.google.android.gms.maps.model.MapColorScheme;
 import com.rnmaps.maps.MapMarker;
-import com.rnmaps.maps.MapOverlay;
 import com.rnmaps.maps.MapView;
 import com.rnmaps.maps.SizeReportingShadowNode;
 
-import java.util.List;
 import java.util.Map;
 
 @ReactModule(name = MapViewManager.REACT_CLASS)

--- a/android/src/main/java/com/rnmaps/maps/MapView.java
+++ b/android/src/main/java/com/rnmaps/maps/MapView.java
@@ -1244,7 +1244,10 @@ public class MapView extends com.google.android.gms.maps.MapView implements Goog
     }
 
     public View getFeatureAt(int index) {
-        return features.get(index);
+        if (index < features.size()) {
+            return features.get(index);
+        }
+        return null;
     }
 
     public void removeFeatureAt(int index) {


### PR DESCRIPTION

### Does any other open PR do the same thing?

No


### What issue is this PR fixing?

https://github.com/react-native-maps/react-native-maps/pull/5765#issuecomment-3401212807

### How did you test this PR?
checking the stacktrace and making sure we don't call List.get(index) if index > size
