### PR TITLE
Fix IOS Google Maps onRegionChangeComplete event returning incorrect region

### DIFF
--- a/ios/AirGoogleMaps/AIRGoogleMap.mm
+++ b/ios/AirGoogleMaps/AIRGoogleMap.mm
@@ -747,24 +747,16 @@ id regionAsJSON(MKCoordinateRegion region) {
 }
 
 + (MKCoordinateRegion) makeGMSCameraPositionFromMap:(GMSMapView *)map andGMSCameraPosition:(GMSCameraPosition *)position {
-  // solution from here: http://stackoverflow.com/a/16587735/1102215
-  GMSVisibleRegion visibleRegion = map.projection.visibleRegion;
-  GMSCoordinateBounds *bounds = [[GMSCoordinateBounds alloc] initWithRegion: visibleRegion];
-  CLLocationCoordinate2D center;
-  CLLocationDegrees longitudeDelta;
-  CLLocationDegrees latitudeDelta = bounds.northEast.latitude - bounds.southWest.latitude;
+  CLLocationCoordinate2D center = map.camera.target;
 
-  if(bounds.northEast.longitude >= bounds.southWest.longitude) {
-    //Standard case
-    center = CLLocationCoordinate2DMake((bounds.southWest.latitude + bounds.northEast.latitude) / 2,
-                                        (bounds.southWest.longitude + bounds.northEast.longitude) / 2);
-    longitudeDelta = bounds.northEast.longitude - bounds.southWest.longitude;
-  } else {
-    //Region spans the international dateline
-    center = CLLocationCoordinate2DMake((bounds.southWest.latitude + bounds.northEast.latitude) / 2,
-                                        (bounds.southWest.longitude + bounds.northEast.longitude + 360) / 2);
-    longitudeDelta = bounds.northEast.longitude + 360 - bounds.southWest.longitude;
-  }
+  GMSVisibleRegion visibleRegion = map.projection.visibleRegion;
+  
+  CLLocationCoordinate2D ne = visibleRegion.farRight;   // North-East corner
+  CLLocationCoordinate2D sw = visibleRegion.nearLeft;   // South-West corner
+
+  CLLocationDegrees latitudeDelta = fabs(ne.latitude - sw.latitude);
+  CLLocationDegrees longitudeDelta = fabs(ne.longitude - sw.longitude);
+  
   MKCoordinateSpan span = MKCoordinateSpanMake(latitudeDelta, longitudeDelta);
   return MKCoordinateRegionMake(center, span);
 }


### PR DESCRIPTION
<!--
PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.

**What happens if you SKIP this step?**

Your pull request will NOT be evaluated!

PLEASE NOTE THAT PRs WITHOUT THE TEMPLATE IN PLACE WILL BE CLOSED RIGHT FROM THE START.

Thanks for helping us help you!
-->

### Does any other open PR do the same thing?

<!--
**Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**

If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)
 -->

No

### What issue is this PR fixing?

IOS Google Maps `onRegionChangeComplete` event is returning wrong `region` coordinates. This PR fixes it.
Fixes #5780

### How did you test this PR?

<!--
Please let us know how you have verified that your changes work.

Ideally, your PR should contain a step-by-step test plan, so that reviewers can easily verify your changes.

Your PR will have much better chances of being merged if it is straightforward to verify.

Some questions you might want to think about:

- Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any?
- Did you test this on a real device, or in a simulator?
- Are there any platforms you were not able to test?
-->

- IOS Google Maps
- Tested on IOS 18 & 26 Simulator.

<!--
Thanks for your contribution :)
-->
