### PR TITLE
fix(android): implement userInterfaceStyle prop

### DIFF
--- a/android/src/main/java/com/rnmaps/fabric/MapViewManager.java
+++ b/android/src/main/java/com/rnmaps/fabric/MapViewManager.java
@@ -476,7 +476,7 @@ public class MapViewManager extends ViewGroupManager<MapView> implements RNMapsM
 
     @Override
     public void setUserInterfaceStyle(MapView view, @Nullable String value) {
-        // do nothing (initialProp)
+        view.setUserInterfaceStyle(value);
     }
 
     @Override

--- a/android/src/main/java/com/rnmaps/maps/MapView.java
+++ b/android/src/main/java/com/rnmaps/maps/MapView.java
@@ -55,6 +55,7 @@ import com.google.android.gms.maps.model.IndoorBuilding;
 import com.google.android.gms.maps.model.IndoorLevel;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.LatLngBounds;
+import com.google.android.gms.maps.model.MapColorScheme;
 import com.google.android.gms.maps.model.MapStyleOptions;
 import com.google.android.gms.maps.model.Marker;
 import com.google.android.gms.maps.model.MarkerOptions;
@@ -170,6 +171,7 @@ public class MapView extends com.google.android.gms.maps.MapView implements Goog
     private Boolean scrollEnabled;
     private Boolean scrollDuringRotateOrZoomEnabled;
     private String kmlSrc = null;
+    private String userInterfaceStyle = null;
 
     private static boolean contextHasBug(Context context) {
         return context == null ||
@@ -507,6 +509,9 @@ public class MapView extends com.google.android.gms.maps.MapView implements Goog
         }
         if (scrollDuringRotateOrZoomEnabled != null) {
             setScrollDuringRotateOrZoomEnabled(scrollDuringRotateOrZoomEnabled);
+        }
+        if (userInterfaceStyle != null) {
+            setUserInterfaceStyle(userInterfaceStyle);
         }
         if (hasPermissions()) {
             //noinspection MissingPermission
@@ -976,6 +981,19 @@ public class MapView extends com.google.android.gms.maps.MapView implements Goog
         this.customMapStyleString = customMapStyleString;
         if (map != null && customMapStyleString != null) {
             map.setMapStyle(new MapStyleOptions(customMapStyleString));
+        }
+    }
+
+    public void setUserInterfaceStyle(@Nullable String userInterfaceStyle) {
+        this.userInterfaceStyle = userInterfaceStyle;
+        if (map != null && userInterfaceStyle != null) {
+            if ("system".equals(userInterfaceStyle)) {
+                map.setMapColorScheme(MapColorScheme.FOLLOW_SYSTEM);
+            } else if ("light".equals(userInterfaceStyle)) {
+                map.setMapColorScheme(MapColorScheme.LIGHT);
+            } else if ("dark".equals(userInterfaceStyle)) {
+                map.setMapColorScheme(MapColorScheme.DARK);
+            }
         }
     }
 

--- a/example/src/examples/ThemeMap.tsx
+++ b/example/src/examples/ThemeMap.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import {StyleSheet, View, Text, Dimensions, ScrollView} from 'react-native';
-import MapView, {Marker} from 'react-native-maps';
+import {StyleSheet, View, Dimensions, ScrollView, Button} from 'react-native';
+import MapView, {Marker, type MapViewProps} from 'react-native-maps';
 
 const {width, height} = Dimensions.get('window');
 
@@ -21,6 +21,7 @@ class ThemeMap extends React.Component<any, any> {
         latitudeDelta: LATITUDE_DELTA,
         longitudeDelta: LONGITUDE_DELTA,
       },
+      userInterfaceStyle: 'system' as MapViewProps['userInterfaceStyle'],
     };
   }
 
@@ -28,23 +29,21 @@ class ThemeMap extends React.Component<any, any> {
     return (
       <View style={styles.container}>
         <ScrollView contentContainerStyle={styles.scrollview}>
-          <Text>System</Text>
-          <MapView
-            provider={this.props.provider}
-            style={styles.map}
-            scrollEnabled={false}
-            zoomEnabled={false}
-            pitchEnabled={false}
-            rotateEnabled={false}
-            initialRegion={this.state.region}>
-            <Marker
-              title="This is a title"
-              description="This is a description"
-              coordinate={this.state.region}
-            />
-          </MapView>
+          <View style={styles.buttonContainer}>
+            {(['system', 'light', 'dark'] as const).map(userInterfaceStyle => (
+              <Button
+                key={userInterfaceStyle + this.state.userInterfaceStyle}
+                title={userInterfaceStyle}
+                onPress={() => this.setState({userInterfaceStyle})}
+                color={
+                  this.state.userInterfaceStyle === userInterfaceStyle
+                    ? 'blue'
+                    : undefined
+                }
+              />
+            ))}
+          </View>
 
-          <Text>{'\n'}Light</Text>
           <MapView
             provider={this.props.provider}
             style={styles.map}
@@ -53,23 +52,7 @@ class ThemeMap extends React.Component<any, any> {
             pitchEnabled={false}
             rotateEnabled={false}
             initialRegion={this.state.region}
-            userInterfaceStyle="light">
-            <Marker
-              title="This is a title"
-              description="This is a description"
-              coordinate={this.state.region}
-            />
-          </MapView>
-          <Text>{'\n'}Dark</Text>
-          <MapView
-            provider={this.props.provider}
-            style={styles.map}
-            scrollEnabled={false}
-            zoomEnabled={false}
-            pitchEnabled={false}
-            rotateEnabled={false}
-            initialRegion={this.state.region}
-            userInterfaceStyle="dark">
+            userInterfaceStyle={this.state.userInterfaceStyle}>
             <Marker
               title="This is a title"
               description="This is a description"
@@ -93,8 +76,14 @@ const styles = StyleSheet.create({
     paddingVertical: 70,
   },
   map: {
-    width: 200,
-    height: 200,
+    width: width - 40,
+    height: width - 40,
+  },
+  buttonContainer: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    marginVertical: 10,
+    gap: 10,
   },
 });
 

--- a/src/MapView.tsx
+++ b/src/MapView.tsx
@@ -656,7 +656,7 @@ export type MapViewProps = ViewProps & {
    * @platform iOS: Supported
    * @platform Android: Supported
    */
-  userInterfaceStyle?: 'light' | 'dark';
+  userInterfaceStyle?: 'system' | 'light' | 'dark';
 
   /**
    * The title of the annotation for current user location.


### PR DESCRIPTION
### Does any other open PR do the same thing?
Doesn’t look like it.

### What issue is this PR fixing?

`<MapView userInterfaceStyle="...">` doesn’t do anything on Android.

I only fixed it on Fabric, so this is still broken on Paper; I get the impression that `android/src/main/java/com/rnmaps/maps/MapManager.java` needs to change, but I set `newArchEnabled=false` and `android/src/main/java/com/rnmaps/fabric/MapViewManager.java` was still being constructed so I'm not sure what’s going on there.

### How did you test this PR?

Combined with #5832 and tested using the included changes to the ThemeMap screen in the demo app.