### PR TITLE
(fix): Defer setPadding when map reference is null

### DIFF
--- a/android/src/main/java/com/rnmaps/maps/MapView.java
+++ b/android/src/main/java/com/rnmaps/maps/MapView.java
@@ -1492,6 +1492,16 @@ public class MapView extends com.google.android.gms.maps.MapView implements Goog
     int edgeBottomPadding;
 
     public void applyBaseMapPadding(int left, int top, int right, int bottom) {
+        if (map == null) {
+            // Map instance isn't created yet, calling setPadding() now crashes the app
+            baseLeftMapPadding = left;
+            baseRightMapPadding = right;
+            baseTopMapPadding = top;
+            baseBottomMapPadding = bottom;
+            setPaddingDeferred = true;
+            return;
+        }
+
         if (super.getHeight() <= 0 || super.getWidth() <= 0) {
             // the map is not laid out yet and calling setPadding() now has no effect
             baseLeftMapPadding = left;


### PR DESCRIPTION
I have been using this library for years. I recently migrated my app to the new architecture, and that is when this issue surfaced. Setting padding via MapView props would cause the app to crash on Android when the map instance had not yet been created.

The PR defers setPadding in that case, using the same setPaddingDeferred logic that is used when the map is not laid out yet.

### Does any other open PR do the same thing?

No existing PR found.

### What issue is this PR fixing?

[Related Issue](https://github.com/react-native-maps/react-native-maps/issues/5837)

### How did you test this PR?

I applied a patch based on this PR to my app and it no longer crashes.
