### PR TITLE
fix(ios): pass accuracy, altitude, etc. on user location change for Google Maps

### DIFF
--- a/ios/AirGoogleMaps/RNMapsGoogleMapView.mm
+++ b/ios/AirGoogleMaps/RNMapsGoogleMapView.mm
@@ -309,6 +309,12 @@ using namespace facebook::react;
               facebook::react::RNMapsGoogleMapViewEventEmitter::OnUserLocationChangeCoordinate coordinate = {
                   .latitude = [coordinateDict[@"latitude"] doubleValue],
                   .longitude = [coordinateDict[@"longitude"] doubleValue],
+                  .altitude = [coordinateDict[@"altitude"] doubleValue],
+                  .timestamp = [coordinateDict[@"timestamp"] doubleValue],
+                  .accuracy = [coordinateDict[@"accuracy"] floatValue],
+                  .altitudeAccuracy = [coordinateDict[@"altitudeAccuracy"] floatValue],
+                  .speed = [coordinateDict[@"speed"] floatValue],
+                  .heading = [coordinateDict[@"heading"] floatValue],
               };
               NSString* str = @"";
               if (errorDict){


### PR DESCRIPTION
### Does any other open PR do the same thing?

No.

### What issue is this PR fixing?

[#5764 IOS: onUserLocationChange always gives accuracy, altitude, timestamp and others as zero](https://github.com/react-native-maps/react-native-maps/issues/5764)

### How did you test this PR?

Tested on an iPhone 16 Pro and iPhone Simulator.
