### PR TITLE
fix: fix ci by using a separate publish to npm step that shouldn't require action

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           node-version: 'lts/*'
           cache: yarn
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: yarn --frozen-lockfile
@@ -40,5 +41,16 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{secrets.CI_GITHUB_TOKEN}}
-          NPM_CONFIG_PROVENANCE: true
         run: yarn release
+
+      - name: Publish to npm (if new version)
+        run: |
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          # Check if this version already exists on npm
+          if npm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" version 2>/dev/null; then
+            echo "Version ${PACKAGE_VERSION} already published, skipping"
+          else
+            echo "Publishing ${PACKAGE_NAME}@${PACKAGE_VERSION}"
+            npm publish --provenance --access public
+          fi

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -8,7 +8,7 @@
         "changelogTitle": "# Changelog"
       }
     ],
-    "@semantic-release/npm",
+    ["@semantic-release/npm", {"npmPublish": false}],
     [
       "@semantic-release/git",
       {


### PR DESCRIPTION


If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)

No


### What issue is this PR fixing?

CI

### How did you test this PR?
live