### PR TITLE
fix(android): update marker size in onLayout to fix clipping

### DIFF
--- a/android/src/main/java/com/rnmaps/maps/MapMarker.java
+++ b/android/src/main/java/com/rnmaps/maps/MapMarker.java
@@ -821,7 +821,16 @@ public class MapMarker extends MapFeature {
     @Override
     protected void onLayout(boolean changed, int l, int t, int r, int b) {
         super.onLayout(changed, l, t, r, b);
-        this.height = b - t;
-        this.width = r - l;
+        int newWidth = r - l;
+        int newHeight = b - t;
+        if (newWidth > 0 && newHeight > 0 && (newWidth != this.width || newHeight != this.height)) {
+            this.width = newWidth;
+            this.height = newHeight;
+
+            clearDrawableCache();
+            if (marker != null) {
+                update(true);
+            }
+        }
     }
 }


### PR DESCRIPTION
<!--
PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.

**What happens if you SKIP this step?**

Your pull request will NOT be evaluated!

PLEASE NOTE THAT PRs WITHOUT THE TEMPLATE IN PLACE WILL BE CLOSED RIGHT FROM THE START.

Thanks for helping us help you!
-->

### Does any other open PR do the same thing?

<!--
**Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**

If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)
 -->

I have searched through the existing PRs related to issue #5165. While there have been discussions regarding this behavior, I did not find a pull request that correctly addresses the synchronization between the Android native View layout and the Google Maps marker bitmap dimensions using the onLayout override. My PR provides a robust fix that works even when tracksViewChanges is set to false.

### What issue is this PR fixing?

#5165

### How did you test this PR?

<!--
Please let us know how you have verified that your changes work.

Ideally, your PR should contain a step-by-step test plan, so that reviewers can easily verify your changes.

Your PR will have much better chances of being merged if it is straightforward to verify.

Some questions you might want to think about:

- Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any?
- Did you test this on a real device, or in a simulator?
- Are there any platforms you were not able to test?
-->

- Platform: Android
- Maps API: Google Maps
- Device: Tested on a real Android device.
- Verification: Verified using a custom marker with dynamic content (text/images).
Test Plan:
1. Use a Marker with a custom View that changes its size dynamically (e.g., toggling between a short and long string).
2. Without this PR: The marker's hit area and visual bounds remain at the initial size (often defaulting to 100x100px or clipped), causing the new content to be partially invisible or misaligned.
3. With this PR: The onLayout event captures the new dimensions, updates the internal width/height, and triggers update(true) to refresh the marker's bitmap on the Google Maps layer. The marker now displays correctly at any size.

<!--
Thanks for your contribution :)
-->
