### PR TITLE
fix(ios): add nil check for subview insertion in Apple Maps

### DIFF
--- a/ios/AirMaps/AIRMap.mm
+++ b/ios/AirMaps/AIRMap.mm
@@ -157,7 +157,10 @@ const NSInteger AIRMapMaxZoomLevel = 20;
             [self insertReactSubview:(UIView *)childSubviews[i] atIndex:atIndex];
         }
     }
-    [_reactSubviews insertObject:(UIView *)subview atIndex:(NSUInteger) atIndex];
+    if (subview != nil) {
+        NSUInteger safeIndex = MIN((NSUInteger)atIndex, _reactSubviews.count);
+        [_reactSubviews insertObject:(UIView *)subview atIndex:safeIndex];
+    }
 }
 #pragma clang diagnostic pop
 


### PR DESCRIPTION
<!-- PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION. **What happens if you SKIP this step?** Your pull request will NOT be evaluated! PLEASE NOTE THAT PRs WITHOUT THE TEMPLATE IN PLACE WILL BE CLOSED RIGHT FROM THE START. Thanks for helping us help you! -->

### Does any other open PR do the same thing?

<!-- **Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!** If another PR exists that has similar scope to yours, please specify why you opened yours. This could be one of the following (but not limited to) - the previous PR is stalled, as it's really old and the author didn't continue working on it - there are conflicts with the `master` branch and the author didn't fix them - the PR doesn't apply anymore (please specify why) - my PR is better (please specify why) -->

PR #5230 addressed the same issue for Apple Maps, but it was automatically closed as stale on March 10, 2025 without any review or merge. The author did not continue working on it. Issue #5345 remains open and the crash is still reproducible on the latest version.

### What issue is this PR fixing?

Fixes #5345
Related: #5217, #5230

### How did you test this PR?

<!-- Please let us know how you have verified that your changes work. Ideally, your PR should contain a step-by-step test plan, so that reviewers can easily verify your changes. Your PR will have much better chances of being merged if it is straightforward to verify. Some questions you might want to think about: - Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any? - Did you test this on a real device, or in a simulator? - Are there any platforms you were not able to test? -->

- **Platform**: iOS (Apple Maps)
- **Environment**: Expo SDK 54, React Native with New Architecture enabled, iOS 26.2
- **Device**: Real device — iPhone 16 Pro (not simulator)
- **Before fix**: Frequent `NSInvalidArgumentException` crash (`object cannot be nil`) when dynamically adding/removing map markers during zoom/pan
- **After fix**: Zero crashes over several months of production use
- **Side effects**: None — markers display correctly, no disappearing markers (which was a concern raised in the related Google Maps PR #5226)

<!-- Thanks for your contribution :) -->
