### PR TITLE
fix(ios): guard against nil localizedDescription in didFailToLocateUserWithError

### DIFF
--- a/ios/AirMaps/AIRMapManager.m
+++ b/ios/AirMaps/AIRMapManager.m
@@ -1241,7 +1241,8 @@ static int kDragCenterContext;
 #pragma mark MKMapViewDelegate - Tracking the User Location
 
 - (void)mapView:(AIRMap *)mapView didFailToLocateUserWithError:(NSError *)error {
-    id event = @{@"error": @{ @"message": error.localizedDescription }};
+    NSString *message = error.localizedDescription ?: @"Unknown error";
+    id event = @{@"error": @{ @"message": message }};
     if (mapView.onUserLocationChange) {
         mapView.onUserLocationChange(event);
     }


### PR DESCRIPTION
## Summary

Fixes a crash in `AIRMapManager.m` where `error.localizedDescription` can be `nil`, causing an `NSInvalidArgumentException` when constructing the NSDictionary literal.

**Crash:**
```
NSInvalidArgumentException: *** -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: 
attempt to insert nil object from objects[0]
```

**Stack trace:**
```
-[AIRMapManager mapView:didFailToLocateUserWithError:] (AIRMapManager.m:1244)
-[MKMapView locationManagerFailedToUpdateLocation:withError:]
-[MKLocationManager _reportLocationFailureWithError:]
```

## Root cause

`NSError.localizedDescription` is documented to always return a non-nil string, but edge cases exist (custom error domains, specific iOS versions) where it can return `nil`. The Objective-C dictionary literal `@{ @"message": nil }` crashes immediately.

## Fix

Add a nil-coalescing fallback: `error.localizedDescription ?: @"Unknown error"`

This is a one-line change with zero risk — it only affects the nil case which currently crashes.

## Related

- #5505 — same crash signature, closed without code fix
- #5528 — similar nil object crash pattern
- #5871 — related nil check PR for a different method

## Test plan

- [x] Verified the fix compiles in Xcode
- [x] Confirmed the crash no longer occurs when `localizedDescription` is nil
- [x] No behavioral change for the normal (non-nil) case