### PR TITLE
fix(ios): guard against nil subview in insertReactSubview:atIndex:

### DIFF
--- a/ios/AirGoogleMaps/AIRGoogleMap.mm
+++ b/ios/AirGoogleMaps/AIRGoogleMap.mm
@@ -245,6 +245,7 @@ id regionAsJSON(MKCoordinateRegion region) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wobjc-missing-super-calls"
 - (void)insertReactSubview:(id<RCTComponent>)subview atIndex:(NSInteger)atIndex {
+  if (subview == nil) return;
   // Our desired API is to pass up markers/overlays as children to the mapview component.
   // This is where we intercept them and do the appropriate underlying mapview action.
   if ([subview isKindOfClass:[AIRGoogleMapMarker class]]) {

--- a/ios/AirMaps/AIRMap.mm
+++ b/ios/AirMaps/AIRMap.mm
@@ -126,6 +126,7 @@ const NSInteger AIRMapMaxZoomLevel = 20;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wobjc-missing-super-calls"
 - (void)insertReactSubview:(id<RCTComponent>)subview atIndex:(NSInteger)atIndex {
+    if (subview == nil) return;
     // Our desired API is to pass up markers/overlays as children to the mapview component.
     // This is where we intercept them and do the appropriate underlying mapview action.
     if ([subview isKindOfClass:[AIRMapMarker class]]) {


### PR DESCRIPTION
## Summary

- Add nil check for `subview` parameter at the top of `insertReactSubview:atIndex:` in both `AIRGoogleMap` and `AIRMap`
- Prevents `NSInvalidArgumentException` crash when `[_reactSubviews insertObject:nil atIndex:]` is called

## Problem

When using Fabric (New Architecture), the interop layer (`RCTLegacyViewManagerInteropComponentView`) can pass a nil `contentView` to `insertReactSubview:atIndex:` during marker mount transactions. Since `NSMutableArray` does not accept nil, this crashes with:

```
NSInvalidArgumentException: *** -[__NSArrayM insertObject:atIndex:]: object cannot be nil
```

Stack trace:
```
CoreFoundation        -[__NSArrayM insertObject:atIndex:]
AIRGoogleMap          -[AIRGoogleMap insertReactSubview:atIndex:]
RCTLegacyViewManagerInteropComponentView  -[... finalizeUpdates:]
RCTMountingManager    -[RCTMountingManager performTransaction:]
```

This is reproducible when map subviews (markers) are dynamically added/removed, e.g. during a search that filters markers.

## Fix

Early return when `subview` is nil. A nil subview has nothing valid to add — no marker, no overlay, no entry in `_reactSubviews`. This is the minimal defensive fix that doesn't change any existing behavior for non-nil subviews.

## Test plan

- [ ] Verify markers still render correctly on iOS with Google Maps (Fabric enabled)
- [ ] Verify markers still render correctly on iOS with Apple Maps (Fabric enabled)
- [ ] Rapidly add/remove markers (e.g. via search filtering) — no crash
- [ ] Existing marker interaction (select, deselect, drag) still works

Fixes #5217
Fixes #5345
Related: expo/expo#34614

🤖 Generated with [Claude Code](https://claude.com/claude-code)