### PR TITLE
fix(android): bounds checks for Fabric stale indices in feature operations

### DIFF
--- a/android/src/main/java/com/rnmaps/maps/MapLocalTile.java
+++ b/android/src/main/java/com/rnmaps/maps/MapLocalTile.java
@@ -146,6 +146,8 @@ public class MapLocalTile extends MapFeature {
 
     @Override
     public void removeFromMap(Object map) {
-        tileOverlay.remove();
+        if (tileOverlay != null) {
+            tileOverlay.remove();
+        }
     }
 }

--- a/android/src/main/java/com/rnmaps/maps/MapUrlTile.java
+++ b/android/src/main/java/com/rnmaps/maps/MapUrlTile.java
@@ -202,6 +202,8 @@ public class MapUrlTile extends MapFeature {
 
   @Override
   public void removeFromMap(Object map) {
-    tileOverlay.remove();
+    if (tileOverlay != null) {
+      tileOverlay.remove();
+    }
   }
 }

--- a/android/src/main/java/com/rnmaps/maps/MapView.java
+++ b/android/src/main/java/com/rnmaps/maps/MapView.java
@@ -1187,6 +1187,15 @@ public class MapView extends com.google.android.gms.maps.MapView implements Goog
     }
 
     public void addFeature(View child, int index) {
+        // Clamp index to valid bounds. The Fabric renderer can issue mount instructions
+        // with stale indices that exceed the current feature count during rapid updates
+        // (e.g. clustering, panning, or toggling tile overlays on/off).
+        if (index < 0) {
+            index = 0;
+        } else if (index > features.size()) {
+            index = features.size();
+        }
+
         // Our desired API is to pass up annotations/overlays as children to the mapview component.
         // This is where we intercept them and do the appropriate underlying mapview action.
         if (child instanceof MapMarker) {
@@ -1277,13 +1286,16 @@ public class MapView extends com.google.android.gms.maps.MapView implements Goog
     }
 
     public View getFeatureAt(int index) {
-        if (index < features.size()) {
+        if (index >= 0 && index < features.size()) {
             return features.get(index);
         }
         return null;
     }
 
     public void removeFeatureAt(int index) {
+        if (index < 0 || index >= features.size()) {
+            return;
+        }
         MapFeature feature = features.remove(index);
         if (feature instanceof MapMarker) {
             markerMap.remove(feature.getFeature());


### PR DESCRIPTION
### Does any other open PR do the same thing?

- #5511 proposed the same bounds checks but was closed without merge
- #5859 takes a different approach (savedFeatures redirect) but doesn't address the index clamping in `addFeature` or the tile overlay null safety

This PR is a minimal, focused fix for the index bounds crashes.

### What issue is this PR fixing?

- #5863 — `IndexOutOfBoundsException` in `removeFeatureAt` / `getFeatureAt` with Fabric renderer
- #5807 — App crashes when dynamically adding/removing `UrlTile` components from `MapView`

Both issues share the same root cause: the Fabric renderer can issue mount/unmount instructions with stale indices that don't match the current `features` list size. This happens during rapid child updates (marker clustering, map panning, toggling tile overlays on/off).

### Root cause

Fabric's shadow tree and the native `features` ArrayList can become temporarily out of sync. When Fabric dispatches a batched mount item with an index based on the shadow tree state, the native list may have already changed size — causing `IndexOutOfBoundsException` on `ArrayList.add()` or `ArrayList.remove()`.

### Changes

**`MapView.java`:**
- **`addFeature`**: Clamp index to `[0, features.size()]` before processing. This is the same approach that was proposed in #5511 and confirmed working by @Bordei08 in #5863.
- **`removeFeatureAt`**: Add bounds guard (`index < 0 || index >= features.size()`) to silently skip stale remove indices instead of crashing.
- **`getFeatureAt`**: Add `index >= 0` check (previously only checked upper bound).

**`MapUrlTile.java` / `MapLocalTile.java`:**
- Add null check on `tileOverlay` in `removeFromMap()` to prevent `NullPointerException` when a tile overlay is removed before it was fully added (rapid toggle scenario from #5807). `MapWMSTile` inherits this fix via `MapUrlTile`.

### How did you test this PR?

- Platform: Android with Google Maps (Fabric / New Architecture enabled)
- Tested on a real device with react-native-maps 1.27.1
- Reproduced #5863 by rapidly panning a map with 200+ clustered markers, causing Fabric to send stale indices — crash no longer occurs
- Reproduced #5807 by toggling UrlTile components on/off while panning — crash no longer occurs
- Verified no behavioral change for normal (in-bounds) operations
- iOS is not affected by these issues

### Risk assessment

This is a defensive-only change — all four modifications only affect the error case (out-of-bounds index or null overlay) which currently crashes. Normal operation is completely unchanged.