### PR TITLE
fix: remove features from map when MapView is detached, clear polylineOptions on polyline remove

### DIFF
--- a/android/src/main/java/com/rnmaps/maps/MapPolyline.java
+++ b/android/src/main/java/com/rnmaps/maps/MapPolyline.java
@@ -190,6 +190,7 @@ public class MapPolyline extends MapFeature {
     @Override
     public void removeFromMap(Object collection) {
         PolylineManager.Collection polylineCollection = (PolylineManager.Collection) collection;
+        polylineOptions = null;
         polylineCollection.remove(polyline);
     }
 

--- a/android/src/main/java/com/rnmaps/maps/MapView.java
+++ b/android/src/main/java/com/rnmaps/maps/MapView.java
@@ -378,6 +378,9 @@ public class MapView extends com.google.android.gms.maps.MapView implements Goog
         }
 
         savedFeatures = new ArrayList<>(features);
+        features.forEach(feature -> {
+            removeFeatureFromMap(feature);
+        });
         features.clear();
         shouldRestorePadding = true;
         removeView(attacherGroup);
@@ -1283,8 +1286,7 @@ public class MapView extends com.google.android.gms.maps.MapView implements Goog
         return null;
     }
 
-    public void removeFeatureAt(int index) {
-        MapFeature feature = features.remove(index);
+    private void removeFeatureFromMap(MapFeature feature) {
         if (feature instanceof MapMarker) {
             markerMap.remove(feature.getFeature());
             feature.removeFromMap(markerCollection);
@@ -1303,6 +1305,11 @@ public class MapView extends com.google.android.gms.maps.MapView implements Goog
         } else if (feature != null) {
             feature.removeFromMap(map);
         }
+    }
+
+    public void removeFeatureAt(int index) {
+        MapFeature feature = features.remove(index);
+        removeFeatureFromMap(feature);
     }
 
     public WritableMap makeClickEventData(LatLng point) {


### PR DESCRIPTION
### Does any other open PR do the same thing?

<!--
**Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**

If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)
 -->

Did not find one

### What issue is this PR fixing?

https://github.com/react-native-maps/react-native-maps/issues/5901

### How did you test this PR?

<!--
Please let us know how you have verified that your changes work.

Ideally, your PR should contain a step-by-step test plan, so that reviewers can easily verify your changes.

Your PR will have much better chances of being merged if it is straightforward to verify.

Some questions you might want to think about:

- Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any?
- Did you test this on a real device, or in a simulator?
- Are there any platforms you were not able to test?
-->

Affects only Android, Tested on emulator. Problem is that when polylines are added back when MapView is attached to window, there already exists `polylineOptions` with old (initial) `coordinates` and other values. This change:
a) calls `removeFromMap` on all features when MapView is detached from window
b) sets `polylineOptions` to `null`, so they are recreated after re-attaching

I am really not sure about a), I may be missing something, but since all features are added back when the MapView is attached, it makes sense to me to remove them all when MapView is detached.

Anyway re-creating `polylineOptions` on every `addToMap` call would be enough to fix the issue.

I've tested if it's not fixed by this PR https://github.com/react-native-maps/react-native-maps/pull/5866, since it does some cleanup, but no.

<!--
Thanks for your contribution :)
-->
