### PR TITLE
fix(android): custom Marker views clipped due to undersized bitmap

### DIFF
--- a/android/src/main/java/com/rnmaps/maps/MapMarker.java
+++ b/android/src/main/java/com/rnmaps/maps/MapMarker.java
@@ -9,6 +9,7 @@ import android.graphics.drawable.Animatable;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.view.View;
+import android.view.ViewGroup;
 import android.widget.LinearLayout;
 import android.animation.ObjectAnimator;
 import android.util.Property;
@@ -658,6 +659,22 @@ public class MapMarker extends MapFeature {
 
     private Bitmap mLastBitmapCreated = null;
 
+    // Walks the subtree to find the union of descendant bounds for bitmap sizing.
+    // Uses only laid-out dimensions — do NOT call View#measure() here (Fabric assertion).
+    private void expandSnapshotSizeFromSubtree(View view, int offsetX, int offsetY, int[] outWh) {
+        int w = view.getWidth() > 0 ? view.getWidth() : view.getMeasuredWidth();
+        int h = view.getHeight() > 0 ? view.getHeight() : view.getMeasuredHeight();
+        outWh[0] = Math.max(outWh[0], offsetX + w);
+        outWh[1] = Math.max(outWh[1], offsetY + h);
+        if (view instanceof ViewGroup) {
+            ViewGroup group = (ViewGroup) view;
+            for (int i = 0; i < group.getChildCount(); i++) {
+                View child = group.getChildAt(i);
+                expandSnapshotSizeFromSubtree(child, offsetX + child.getLeft(), offsetY + child.getTop(), outWh);
+            }
+        }
+    }
+
     private void clearDrawableCache() {
         mLastBitmapCreated = null;
     }
@@ -665,6 +682,27 @@ public class MapMarker extends MapFeature {
     private Bitmap createDrawable() {
         int width = this.width <= 0 ? 100 : this.width;
         int height = this.height <= 0 ? 100 : this.height;
+
+        // Bitmap must cover laid-out custom-marker subtree; Yoga box alone can be too small (Fabric).
+        if (hasCustomMarkerView) {
+            int[] expanded = new int[] { width, height };
+            for (int i = 0; i < getChildCount(); i++) {
+                View child = getChildAt(i);
+                if (child instanceof MapCallout) {
+                    continue;
+                }
+                expandSnapshotSizeFromSubtree(child, child.getLeft(), child.getTop(), expanded);
+            }
+            width = expanded[0];
+            height = expanded[1];
+        }
+
+        if (width <= 0) {
+            width = 100;
+        }
+        if (height <= 0) {
+            height = 100;
+        }
 
         // Do not create the doublebuffer-bitmap each time. reuse it to save memory.
         Bitmap bitmap = mLastBitmapCreated;


### PR DESCRIPTION
<!--
PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.

**What happens if you SKIP this step?**

Your pull request will NOT be evaluated!

PLEASE NOTE THAT PRs WITHOUT THE TEMPLATE IN PLACE WILL BE CLOSED RIGHT FROM THE START.

Thanks for helping us help you!
-->

### Does any other open PR do the same thing?

<!--
**Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**

If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)
 -->

[#5860](https://github.com/react-native-maps/react-native-maps/pull/5860) targets the same symptom (clipped custom markers on Android) but uses a different approach — it updates this.width/this.height in onLayout and triggers a marker refresh when dimensions change. That fix helps when onLayout eventually fires with correct dimensions, but does not cover the Fabric case where the marker's own Yoga layout box is "correct" from Yoga's perspective yet still smaller than the laid-out React subtree. This PR fixes it at createDrawable() time by walking the subtree to compute the union of descendant bounds for the bitmap. The two approaches are complementary. PR [#5860](https://github.com/bkingery/react-native-maps/issues/5860) has been open since February 2026 with no merge activity.

### What issue is this PR fixing?

#5877 Custom View markers broken with New Architecture (invisible, clipped to quarter circles, or flickering)
#5728 Custom markers don't display fully with tracksViewChanges={false}
#5165 Markers are clipped on Android
#5906 is related but describes a different root cause — it's about the Fabric renderer rasterizing the bitmap before async remote images finish loading (a timing/snapshot problem)

### How did you test this PR?

<!--
Please let us know how you have verified that your changes work.

Ideally, your PR should contain a step-by-step test plan, so that reviewers can easily verify your changes.

Your PR will have much better chances of being merged if it is straightforward to verify.

Some questions you might want to think about:

- Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any?
- Did you test this on a real device, or in a simulator?
- Are there any platforms you were not able to test?
-->

Verified using a local patch on Pixel 10 device. See screenshots below.

1. Create a Fabric-enabled app with a custom `Marker` whose child views are larger than the Yoga-assigned marker box (e.g., the reproduction cases from [#5877](https://github.com/bkingery/react-native-maps/issues/5877) — concentric circle markers, cluster markers with text)
2. Verify custom markers render fully without clipping
3. Verify no Fabric ReactViewGroup assertion crashes ("must be measured before being added to a parent")
4. Verify default pin markers and image-only markers still render correctly
5. Verify markers with MapCallout children still work correctly
6. Verify tracksViewChanges={false} works without visual regressions

Example code:
```js
import { Platform, StyleSheet, Text, View } from 'react-native';
import MapView, { Marker, PROVIDER_GOOGLE } from 'react-native-maps';

export function CustomMarkerRepro() {
  return (
    <MapView
      style={StyleSheet.absoluteFill}
      provider={Platform.OS === 'android' ? PROVIDER_GOOGLE : undefined}
      initialRegion={{
        latitude: 37.78825,
        longitude: -122.4324,
        latitudeDelta: 0.05,
        longitudeDelta: 0.05,
      }}
    >
      <Marker coordinate={{ latitude: 37.78825, longitude: -122.4324 }}>
        <View style={styles.pill}>
          <Text style={styles.price}>$1,234</Text>
        </View>
      </Marker>
    </MapView>
  );
}

const styles = StyleSheet.create({
  pill: {
    flexShrink: 0,
    alignItems: 'center',
    justifyContent: 'center',
    paddingHorizontal: 16,
    paddingVertical: 4,
    borderRadius: 16,
    borderWidth: 1,
    backgroundColor: '#fff',
  },
  price: {
    fontSize: 14,
    fontWeight: '600',
  },
});
```

<!--
Thanks for your contribution :)
-->


### Summary

- Fix custom `<Marker>` views on Android being clipped when rasterized to a Google Maps icon on React Native Fabric
- Add `expandSnapshotSizeFromSubtree()` helper that walks the marker's view hierarchy and computes the union of descendant bounds to determine minimum bitmap dimensions
- Only uses laid-out dimensions (`getWidth`/`getHeight`, fallback `getMeasuredWidth`/`getMeasuredHeight`) — never calls `View#measure()`, which would trigger Fabric's `ReactViewGroup` assertion

### Problem

On Fabric, the Yoga layout box for a `MapMarker` can be smaller than its laid-out React subtree. Since `createDrawable()` uses the marker view's `width`/`height` to allocate the `Bitmap`, custom marker content gets clipped.

### Approach

A recursive helper accumulates `left`/`top` offsets while walking the subtree, computing `offset + size` for each descendant to find the true right/bottom edges (union of bounds). This aligns with the iOS approach in `AIRGoogleMapMarker` (`layoutSubviews` uses max right/bottom from child frames).

Non-custom markers (default pin, image-only) are unaffected — the new path only runs when `hasCustomMarkerView` is true. `MapCallout` children are skipped, consistent with existing library convention.

### Alignment with iOS behavior
On Google Maps iOS, custom marker content is hosted in an iconView whose size is derived from subview frames in AIRGoogleMapMarker’s layoutSubviews (effectively growing the container to fit laid-out children). On Apple Maps iOS, AIRMapMarker similarly adjusts bounds when the first child’s frame is larger than the marker’s React frame (layoutSubviews → reactSetFrame:). Android has no live iconView path—markers use a rasterized bitmap—so this change applies the same idea at snapshot time: bitmap dimensions are expanded using already laid-out subtree sizes instead of trusting only the parent Yoga box, avoiding clipped custom markers without calling measure() on Fabric-managed views. See [AIRGoogleMapMarker](https://github.com/react-native-maps/react-native-maps/blob/99183afdd8c4d814cc05e324c9e8c60fd812c2da/ios/AirGoogleMaps/AIRGoogleMapMarker.m#L62-L76) and [AIRMapMarker](https://github.com/react-native-maps/react-native-maps/blob/99183afdd8c4d814cc05e324c9e8c60fd812c2da/ios/AirMaps/AIRMapMarker.m#L421-L433) for current iOS behavior.

| Before | After |
|--|--|
|<img width="417" height="475" alt="Screenshot 2026-05-06 at 3 32 51 PM" src="https://github.com/user-attachments/assets/9e7dc02b-8efb-41fb-9dd2-756d841ce449" />|<img width="504" height="643" alt="Screenshot 2026-05-06 at 3 32 40 PM" src="https://github.com/user-attachments/assets/0d405e2c-1423-416f-9e03-a40f843106ec" />|