### PR TITLE
fix(android): resolve custom marker cutting, flickering, and UI threading crashes

### DIFF
--- a/android/src/main/java/com/rnmaps/maps/MapMarker.java
+++ b/android/src/main/java/com/rnmaps/maps/MapMarker.java
@@ -347,6 +347,7 @@ public class MapMarker extends MapFeature {
         if (updated > 0) {
             updated--;
         }
+        new Handler(Looper.getMainLooper()).post(() -> tracksViewChangesActive = false);
         return true;
     }
 

--- a/android/src/main/java/com/rnmaps/maps/ViewChangesTracker.java
+++ b/android/src/main/java/com/rnmaps/maps/ViewChangesTracker.java
@@ -15,13 +15,13 @@ public class ViewChangesTracker {
   private final long fps = 40;
 
   private ViewChangesTracker() {
-    handler = new Handler(Looper.myLooper());
+    handler = new Handler(Looper.getMainLooper());
     updateRunnable = new Runnable() {
       @Override
       public void run() {        
         update();
 
-        if (markers.size() > 0) {
+        if (!markers.isEmpty()) {
           handler.postDelayed(updateRunnable, fps);
         } else {
           hasScheduledFrame = false;
@@ -67,7 +67,7 @@ public class ViewChangesTracker {
     }
 
     // Remove markers that are not active anymore
-    if (markersToRemove.size() > 0) {
+    if (!markersToRemove.isEmpty()) {
       markers.removeAll(markersToRemove);
       markersToRemove.clear();
     }


### PR DESCRIPTION
### Does any other open PR do the same thing?

This PR is a clean, conflict-free, and surgical replacement for my previous stalled PR #5536. 

### What issue is this PR fixing?

This PR provides a working, permanent fix for the following open issues:

-  #5531
-  #5527
- #5387
- #5247
- #5239

These issues are either stalled, not maintained, or not addressed yet in the main repository.

### How did you test this PR?

- **Platform affected**: Android (using Google Maps API).
- **Testing environment**: Tested on a real Android device and iOS simulator to ensure zero regressions.
- **Verification**: 
  - Verified that custom markers containing images and text render fully without getting cut off or flickering during their initial mount and subsequent state changes.
  - Verified that rendering is thread-safe and does not trigger any looper-related crashes under modern React Native configurations.

---

### Additional Notes

This PR focuses strictly on the runtime logic:
- Handler changes to ensure all UI operations run on the correct Looper (main thread).
- Timing adjustments in `updateCustomForTracking()` to let the custom view complete its layout/measurement pass before disengaging tracking.
