### PR TITLE
feat(plugin): add expo plugin wrapper factory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ yarn-error.log
 
 # ts outDir
 lib/
+dist/
 
 example/vendor/bundle/
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ See [Setup Instructions for the Included Example Project](docs/examples-setup.md
 
 ## Compatibility
 
+## Expo
+
+If you're using Expo then you'll need to add the `react-native-maps` expo plugin. See [Expo Installation Instructions](docs/installation.md#expo).
+
 ## React Native Compatibility
 
 ### Version Requirements:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,7 +20,7 @@ When using Google Maps on iOS, you need also to obtain an [API key for the iOS S
 
 ## Expo
 
-If you're using Expo, you can add react-native-maps to your project by adding it to the plugins array in your `app.json` or `app.config.js`:
+If you're using Expo, you need to add `react-native-maps` to your project by adding it to the plugins array in your `app.json` or `app.config.js/ts`:
 
 > **Note:** This plugin is only compatible with react-native-maps version 1.22 and above, and requires Expo SDK version 53 or higher.
 
@@ -32,7 +32,11 @@ If you're using Expo, you can add react-native-maps to your project by adding it
 }
 ```
 
+### Google Maps
+
 If you're using Google as the map provider, also provide an API key for the respective platform:
+
+**app.json**
 
 ```json
 {
@@ -48,6 +52,22 @@ If you're using Google as the map provider, also provide an API key for the resp
     ]
   }
 }
+```
+
+**app.config.js/ts**
+
+```ts
+import reactNativeMapsExpoPlugin from "react-native-maps/expo";
+
+export default {
+  ...
+  plugins: [
+    reactNativeMapsExpoPlugin({
+      iosGoogleMapsApiKey: "YOUR_KEY_HERE",
+      androidGoogleMapsApiKey: "YOUR_KEY_HERE"
+    })
+  ]
+};
 ```
 
 ## For bare workflow projects, you'll need to follow the iOS and Android setup instructions below.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,16 @@
     "pod-install": "cd example/ios && RCT_NEW_ARCH_ENABLED=1 bundle exec pod install",
     "bootstrap": "yarn --cwd example && yarn && yarn bundle-install && yarn pod-install"
   },
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "default": "./src/index.ts"
+    },
+    "./expo": {
+      "types": "./plugin/build/expo.d.ts",
+      "default": "./plugin/build/expo.js"
+    }
+  },
   "files": [
     "src",
     "dist",

--- a/plugin/src/expo.ts
+++ b/plugin/src/expo.ts
@@ -1,6 +1,8 @@
 import {name} from '../../package.json';
 import type {ConfigPluginProps} from './types';
 
-export default (
+const reactNativeMapsExpoPlugin = (
   props: ConfigPluginProps = {},
 ): [typeof name, ConfigPluginProps] => [name, props];
+
+export default reactNativeMapsExpoPlugin;

--- a/plugin/src/expo.ts
+++ b/plugin/src/expo.ts
@@ -1,0 +1,6 @@
+import {name} from '../../package.json';
+import type {ConfigPluginProps} from './types';
+
+export default (
+  props: ConfigPluginProps = {},
+): [typeof name, ConfigPluginProps] => [name, props];

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -1,7 +1,8 @@
+import {name, version} from '../../package.json';
 import {withMapsIOS} from './ios';
 import withMapsAndroid from './android';
 
-import type {ConfigPlugin} from '@expo/config-plugins';
+import {type ConfigPlugin, createRunOncePlugin} from '@expo/config-plugins';
 import type {ConfigPluginProps} from './types';
 
 const withMaps: ConfigPlugin<ConfigPluginProps> = (config, props) => {
@@ -11,4 +12,4 @@ const withMaps: ConfigPlugin<ConfigPluginProps> = (config, props) => {
   return config;
 };
 
-export default withMaps;
+export default createRunOncePlugin(withMaps, name, version);

--- a/plugin/tsconfig.json
+++ b/plugin/tsconfig.json
@@ -2,8 +2,11 @@
   "compilerOptions": {
     "outDir": "build",
     "rootDir": "src",
+    "declaration": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
     "skipLibCheck": true
   },
-  "include": ["./src"],
+  "include": ["./src", "../package.json"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*"]
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -5,5 +5,5 @@
     "emitDeclarationOnly": true,
     "allowImportingTsExtensions": false
   },
-  "include": ["src", "plugin"]
+  "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,6 @@
     "composite": true,
     "verbatimModuleSyntax": true
   },
-  "include": ["src", "plugin"],
+  "include": ["src", "plugin", "package.json"],
   "exclude": ["**/Pods/**", "dist"]
 }


### PR DESCRIPTION
<!--
PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.

**What happens if you SKIP this step?**

Your pull request will NOT be evaluated!

PLEASE NOTE THAT PRs WITHOUT THE TEMPLATE IN PLACE WILL BE CLOSED RIGHT FROM THE START.

Thanks for helping us help you!
-->

### Does any other open PR do the same thing?

<!--
**Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**

If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)
 -->

No

### What issue is this PR fixing?

N/A

### How did you test this PR?

<!--
Please let us know how you have verified that your changes work.

Ideally, your PR should contain a step-by-step test plan, so that reviewers can easily verify your changes.

Your PR will have much better chances of being merged if it is straightforward to verify.

Some questions you might want to think about:

- Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any?
- Did you test this on a real device, or in a simulator?
- Are there any platforms you were not able to test?
-->

Published the package under my personal scope and used in my project to manually test app builds work as intended.

<!--
Thanks for your contribution :)
-->

---

## One Line Summary

Adds a `expo` subpath to have a nicer DX and type-safe config props to match expo plugins pattern.

## Details

### AI Summary

> This fork packages the Expo plugin more cleanly by wrapping the existing maps config plugin as a run-once Expo plugin and exposing it through a dedicated react-native-maps/expo export. It also adjusts the TypeScript build/output so the plugin ships with the right declaration files, and updates the README/install docs to explain Expo setup and usage.

### Motivation

When using the `react-native-maps` in an Expo app you often don't get intellisense with your props, which forced me to import `withMaps` and use a Parameters type to get the plugin config type to then use Typescripts `satisfies` to ensure the props match the type.

```ts
import withMaps from 'react-native-maps/dist/plugin/src'; // 👈 yucky import path feels wrong

type ReactNativeMapsPluginConfig = Parameters<typeof withMaps>[1]; // 👈 TS gymnastics as the config isn't exported cleanly

// plugins...
    [
      'react-native-maps',
      {
        androidGoogleMapsApiKey: 'MY-KEY-HERE',
        iosGoogleMapsApiKey: 'MY-KEY-HERE',
      } satisfies ReactNativeMapsPluginConfig,
    ],
```

Expo SDK v56 recently added [type-safe config plugins](https://expo.dev/changelog/sdk-56#type-safe-config-plugins) and I really like the pattern. I updated my local custom plugins to do the same and thought I should help out to do the same here as it is pretty slick imo.

### Scope

Only affects the plugin usage in expo config file. No side effects or changes to anything else.

#### Steps to use

Update import to target: `import reactNativeMapsExpoPlugin from 'react-native-maps/expo';`
<img width="562" height="82" alt="image" src="https://github.com/user-attachments/assets/4f3a0795-a7e9-4c32-89a2-e607a8fd4594" />

Replace config with plugin function with props:
<img width="645" height="216" alt="image" src="https://github.com/user-attachments/assets/85533d59-6fef-4a8e-83d6-84c22298dcdf" />

Showing intellisense showing in VSCode: (note the expo plugins in the same pattern)
<img width="476" height="408" alt="image" src="https://github.com/user-attachments/assets/046f21ec-e804-45c3-9a86-cf424a72e530" />