### PR TITLE
feat(ios): allow GoogleMaps pod versions to be overridden

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -97,6 +97,18 @@ rn_maps_path = '../node_modules/react-native-maps'
 pod 'react-native-maps/Google', :path => rn_maps_path
 ```
 
+### Overriding Google Maps dependency versions
+
+You can optionally pin specific versions for the Google Maps dependencies by setting global variables in your `Podfile` **before** the `react-native-maps/Google` pod declaration:
+
+```ruby
+$RNMapsGoogleMapsVersion = '10.10.0'
+$RNMapsGoogleMapsUtilsVersion = '7.0.0'
+
+rn_maps_path = '../node_modules/react-native-maps'
+pod 'react-native-maps/Google', :path => rn_maps_path
+```
+
 The app's Info.plist file must contain a NSLocationWhenInUseUsageDescription with a user-facing purpose string explaining clearly and completely why your app needs the location, otherwise Apple will reject your app submission. This is required whether or not you are accessing the users location, as Google Maps iOS SDK contains the code required to access the users location.
 
 That's it, you made it! 👍

--- a/react-native-maps.podspec
+++ b/react-native-maps.podspec
@@ -112,8 +112,22 @@ Pod::Spec.new do |s|
     }
     # Fixed compiler flags to avoid -Wno warnings
     ss.compiler_flags = folly_compiler_flags + ' -DHAVE_GOOGLE_MAPS=1 -DHAVE_GOOGLE_MAPS_UTILS=1'
-    ss.dependency 'GoogleMaps', '9.4.0'
-    ss.dependency 'Google-Maps-iOS-Utils', '6.1.0'
+    
+    google_maps_version = '9.4.0'
+    google_maps_utils_version = '6.1.0'
+
+    if defined?($RNMapsGoogleMapsVersion)
+      Pod::UI.puts "#{s.name}: Using user specified GoogleMaps version '#{$RNMapsGoogleMapsVersion}'"
+      google_maps_version = $RNMapsGoogleMapsVersion
+    end
+
+    if defined?($RNMapsGoogleMapsUtilsVersion)
+      Pod::UI.puts "#{s.name}: Using user specified Google-Maps-iOS-Utils version '#{$RNMapsGoogleMapsUtilsVersion}'"
+      google_maps_utils_version = $RNMapsGoogleMapsUtilsVersion
+    end
+
+    ss.dependency 'GoogleMaps', google_maps_version #'8.4.0'
+    ss.dependency 'Google-Maps-iOS-Utils', google_maps_utils_version #'5.0.0'
     ss.dependency 'react-native-maps/Generated'
     ss.dependency 'react-native-maps/Maps'
     install_modules_dependencies(ss)


### PR DESCRIPTION
<!--
PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.

**What happens if you SKIP this step?**

Your pull request will NOT be evaluated!

PLEASE NOTE THAT PRs WITHOUT THE TEMPLATE IN PLACE WILL BE CLOSED RIGHT FROM THE START.

Thanks for helping us help you!
-->

### Does any other open PR do the same thing?

<!--
**Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**

If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)
 -->

No.

### What issue is this PR fixing?

Provides the ability to hold off on GoogleMaps for iOS SDK updates or update ahead of time without being blocked by this package.

### How did you test this PR?

<!--
Please let us know how you have verified that your changes work.

Ideally, your PR should contain a step-by-step test plan, so that reviewers can easily verify your changes.

Your PR will have much better chances of being merged if it is straightforward to verify.

Some questions you might want to think about:

- Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any?
- Did you test this on a real device, or in a simulator?
- Are there any platforms you were not able to test?
-->

Tested on iOS by updating the example app's Podfile and re-installing pods. 
Verified the default values are used if the Podfile does not provide the variables.
Using the current versions as defaults for backward compatibility.

<!--
Thanks for your contribution :)
-->
