### PR TITLE
fix(iOS): guard didTapPolygon: against non-AIRGMSPolygon overlays (unrecognized-selector crash)

### DIFF
--- a/ios/AirGoogleMaps/AIRGoogleMap.mm
+++ b/ios/AirGoogleMaps/AIRGoogleMap.mm
@@ -502,6 +502,12 @@ id regionAsJSON(MKCoordinateRegion region) {
 }
 
 - (void)didTapPolygon:(GMSOverlay *)polygon {
+    // Only AIRGMSPolygon overlays carry the AIR-specific identifier/onPress; any
+    // other GMSOverlay subclass reaching this handler crashes on the cast below
+    // ("unrecognized selector"). Bail out for anything that isn't an AIRGMSPolygon.
+    if (![polygon isKindOfClass:[AIRGMSPolygon class]]) {
+        return;
+    }
     AIRGMSPolygon *airPolygon = (AIRGMSPolygon *)polygon;
 
     id event = @{@"action": @"polygon-press",


### PR DESCRIPTION
Fixes #5931

## Problem
`-[AIRGoogleMap didTapPolygon:]` unconditionally casts the tapped overlay to `AIRGMSPolygon`. Any other `GMSOverlay` subclass reaching this handler crashes with an unrecognized-selector exception, because the AIR-specific `identifier` / `onPress` selectors don't exist on a plain `GMSPolygon`.

## Fix
Guard the type before casting — return early if the overlay isn't an `AIRGMSPolygon`:

```objc
- (void)didTapPolygon:(GMSOverlay *)polygon {
    if (![polygon isKindOfClass:[AIRGMSPolygon class]]) {
        return;
    }
    AIRGMSPolygon *airPolygon = (AIRGMSPolygon *)polygon;
    // ...
}
```

No behavior change for `AIRGMSPolygon` taps. Verified in an app running 1.27.2 (the same source as current `master`).
