### PR TITLE
fix(iOS): update polygon path when a coordinate value changes (not only on count change)

### DIFF
--- a/ios/AirGoogleMaps/RNMapsGooglePolygonView.mm
+++ b/ios/AirGoogleMaps/RNMapsGooglePolygonView.mm
@@ -168,7 +168,20 @@ bool areHolesEqual(const std::vector<std::vector<RNMapsGooglePolygonHolesStruct>
     if(newViewProps.zIndex.has_value()){
         _view.zIndex = newViewProps.zIndex.value();
     }
-    if (newViewProps.coordinates.size() != oldViewProps.coordinates.size()){
+    // Rebuild the path when the coordinates change in count OR value. Comparing
+    // only the count means moving an existing vertex (same point count, new
+    // lat/lng) never updates the rendered shape.
+    bool coordsChanged = newViewProps.coordinates.size() != oldViewProps.coordinates.size();
+    if (!coordsChanged) {
+        for (size_t i = 0; i < newViewProps.coordinates.size(); i++) {
+            if (newViewProps.coordinates.at(i).latitude  != oldViewProps.coordinates.at(i).latitude ||
+                newViewProps.coordinates.at(i).longitude != oldViewProps.coordinates.at(i).longitude) {
+                coordsChanged = true;
+                break;
+            }
+        }
+    }
+    if (coordsChanged){
         GMSMutablePath *path = [GMSMutablePath path];
         for(int i = 0; i < newViewProps.coordinates.size(); i++)
         {


### PR DESCRIPTION
Fixes #5929

## Problem
On the New Architecture (iOS, `provider="google"`), updating a `<Polygon>`'s coordinates to the same number of points but different positions (i.e. moving a vertex) does not update the rendered shape. Adding or removing a point (a count change) does.

## Cause
`RNMapsGooglePolygonView updateProps:` rebuilds the `GMSMutablePath` only when the coordinate **count** changes:

```objc
if (newViewProps.coordinates.size() != oldViewProps.coordinates.size()) { /* rebuild path */ }
```

## Fix
Rebuild when the coordinates differ in count **or** value (element-wise compare).

Note: `holes` has the same pattern (`areHolesEqual` compares only sizes), so editing a hole vertex would have the same issue — not changed here, but worth a follow-up.

Verified in an app against 1.27.2 (the same source as current `master`).
