### PR TITLE
fix(iOS): render New-Architecture Google Polygon/Geojson overlays (attach the GMSPolygon)

### DIFF
--- a/ios/AirGoogleMaps/AIRGoogleMap.mm
+++ b/ios/AirGoogleMaps/AIRGoogleMap.mm
@@ -257,8 +257,16 @@ id regionAsJSON(MKCoordinateRegion region) {
     [self.polygons addObject:polygon];
 
   } else if ([NSStringFromClass([subview class]) isEqualToString:@"RNMapsGooglePolygonView"]){
-//      RNMapsGooglePolygonView *polygon = (RNMapsGooglePolygonView*)subview;
-//      [polygon didInsertInMap:self];
+      // New-Architecture Google polygon view. Attach the underlying GMSPolygon to
+      // the map; upstream left this commented out, so Polygon/Geojson overlays never
+      // rendered under the New Architecture. Invoked via a dynamic selector to avoid
+      // importing the codegen-only RNMapsGooglePolygonView header here.
+      if ([subview respondsToSelector:@selector(didInsertInMap:)]) {
+        #pragma clang diagnostic push
+        #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+        [subview performSelector:@selector(didInsertInMap:) withObject:self];
+        #pragma clang diagnostic pop
+      }
       [self.polygons addObject:subview];
   } else if ([subview isKindOfClass:[AIRGoogleMapPolyline class]]) {
     AIRGoogleMapPolyline *polyline = (AIRGoogleMapPolyline*)subview;
@@ -305,6 +313,14 @@ id regionAsJSON(MKCoordinateRegion region) {
     marker.realMarker.map = nil;
     [self.markers removeObject:marker];
   } else if ([NSStringFromClass([subview class]) isEqualToString:@"RNMapsGooglePolygonView"]) {
+      // Detach the GMSPolygon from the map; upstream only dropped it from the
+      // tracking array, leaving removed New-Arch overlays stuck on the map.
+      if ([subview respondsToSelector:@selector(didRemoveFromMap)]) {
+        #pragma clang diagnostic push
+        #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+        [subview performSelector:@selector(didRemoveFromMap)];
+        #pragma clang diagnostic pop
+      }
       [self.polygons removeObject:subview];
    } else if ([subview isKindOfClass:[AIRGoogleMapPolygon class]]) {
     AIRGoogleMapPolygon *polygon = (AIRGoogleMapPolygon*)subview;

--- a/ios/AirGoogleMaps/RNMapsGooglePolygonView.mm
+++ b/ios/AirGoogleMaps/RNMapsGooglePolygonView.mm
@@ -55,10 +55,12 @@ bool areHolesEqual(const std::vector<std::vector<RNMapsGooglePolygonHolesStruct>
 }
 
 @interface RNMapsGooglePolygonView () <RCTRNMapsGooglePolygonViewProtocol>
+- (void) attachIfReady;
 @end
 
 @implementation RNMapsGooglePolygonView {
     AIRGMSPolygon *_view;
+    __weak AIRGoogleMap *_pendingMap;
 }
 
 
@@ -73,11 +75,28 @@ bool areHolesEqual(const std::vector<std::vector<RNMapsGooglePolygonHolesStruct>
 
 - (void) didInsertInMap:(AIRGoogleMap*) map
 {
-    _view.map = map;
+    // Defer the attach until the path is renderable. Under Fabric the coordinates
+    // (props) can arrive AFTER mount, and attaching a GMSPolygon whose path has
+    // fewer than 3 points crashes Google Maps (null-deref in gmssdk::CoordsToPoints
+    // during setMap:). Remember the target map and attach from attachIfReady — here
+    // if the path is already valid, otherwise from updateProps once coordinates land.
+    _pendingMap = map;
+    [self attachIfReady];
+}
+
+// Attach to the map only when the polygon has a renderable path. Idempotent: safe
+// to call from both didInsertInMap and updateProps.
+- (void) attachIfReady
+{
+    if (_view != nil && _view.map == nil && _pendingMap != nil
+        && _view.path != nil && _view.path.count >= 3) {
+        _view.map = _pendingMap;
+    }
 }
 
 -(void) didRemoveFromMap
 {
+    _pendingMap = nil;
     _view.map = nil;
     _view = nil;
 }
@@ -209,6 +228,10 @@ bool areHolesEqual(const std::vector<std::vector<RNMapsGooglePolygonHolesStruct>
     if (newViewProps.strokeWidth != oldViewProps.strokeWidth){
         _view.strokeWidth = newViewProps.strokeWidth;
     }
+
+    // Coordinates may have just been applied above; attach now if the mount was
+    // deferred while the path was still empty.
+    [self attachIfReady];
 
   [super updateProps:props oldProps:oldProps];
 }


### PR DESCRIPTION
Fixes #5928

## Problem
With the New Architecture (Fabric) enabled and `provider="google"` on iOS, `<Polygon>` / `<Geojson>` overlays never render. Markers render fine. The `GMSPolygon` is created but never attached to the map.

## Cause
In `AIRGoogleMap.mm`, the `RNMapsGooglePolygonView` branch of `insertReactSubview:` / `removeReactSubview:` has the `didInsertInMap:` / `didRemoveFromMap` calls commented out, so `_view.map` is never set (or cleared).

Attaching unconditionally is also unsafe under Fabric: coordinates can arrive via `updateProps` *after* mount, and attaching a `GMSPolygon` whose path has fewer than 3 points crashes Google Maps (null-deref in `gmssdk::CoordsToPoints` during `setMap:`).

## Fix
- `AIRGoogleMap.mm`: invoke `didInsertInMap:` / `didRemoveFromMap` for the New-Arch polygon view (via a dynamic selector, to avoid importing the codegen-only header).
- `RNMapsGooglePolygonView.mm`: defer the attach until the path is renderable (`attachIfReady`, re-checked from `updateProps`), so a degenerate path is never attached.

Verified in an app against 1.27.2 (the same source as current `master`); overlays now render and clear correctly. I can't build-verify in-repo — please run CI / a device check.
