### PR TITLE
fix(iOS): keep New-Arch polygon overlays attached through a zIndex reorder

### DIFF
--- a/ios/AirGoogleMaps/AIRGoogleMap.mm
+++ b/ios/AirGoogleMaps/AIRGoogleMap.mm
@@ -257,8 +257,16 @@ id regionAsJSON(MKCoordinateRegion region) {
     [self.polygons addObject:polygon];
 
   } else if ([NSStringFromClass([subview class]) isEqualToString:@"RNMapsGooglePolygonView"]){
-//      RNMapsGooglePolygonView *polygon = (RNMapsGooglePolygonView*)subview;
-//      [polygon didInsertInMap:self];
+      // New-Architecture Google polygon view. Attach the underlying GMSPolygon to
+      // the map; upstream left this commented out, so Polygon/Geojson overlays never
+      // rendered under the New Architecture. Invoked via a dynamic selector to avoid
+      // importing the codegen-only RNMapsGooglePolygonView header here.
+      if ([subview respondsToSelector:@selector(didInsertInMap:)]) {
+        #pragma clang diagnostic push
+        #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+        [subview performSelector:@selector(didInsertInMap:) withObject:self];
+        #pragma clang diagnostic pop
+      }
       [self.polygons addObject:subview];
   } else if ([subview isKindOfClass:[AIRGoogleMapPolyline class]]) {
     AIRGoogleMapPolyline *polyline = (AIRGoogleMapPolyline*)subview;
@@ -305,6 +313,14 @@ id regionAsJSON(MKCoordinateRegion region) {
     marker.realMarker.map = nil;
     [self.markers removeObject:marker];
   } else if ([NSStringFromClass([subview class]) isEqualToString:@"RNMapsGooglePolygonView"]) {
+      // Detach the GMSPolygon from the map; upstream only dropped it from the
+      // tracking array, leaving removed New-Arch overlays stuck on the map.
+      if ([subview respondsToSelector:@selector(didRemoveFromMap)]) {
+        #pragma clang diagnostic push
+        #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+        [subview performSelector:@selector(didRemoveFromMap)];
+        #pragma clang diagnostic pop
+      }
       [self.polygons removeObject:subview];
    } else if ([subview isKindOfClass:[AIRGoogleMapPolygon class]]) {
     AIRGoogleMapPolygon *polygon = (AIRGoogleMapPolygon*)subview;

--- a/ios/AirGoogleMaps/RNMapsGooglePolygonView.mm
+++ b/ios/AirGoogleMaps/RNMapsGooglePolygonView.mm
@@ -61,6 +61,8 @@ bool areHolesEqual(const std::vector<std::vector<RNMapsGooglePolygonHolesStruct>
 @implementation RNMapsGooglePolygonView {
     AIRGMSPolygon *_view;
     __weak AIRGoogleMap *_pendingMap;
+    // YES while a GMS detach is queued for the next runloop tick (see didRemoveFromMap).
+    BOOL _detachScheduled;
 }
 
 
@@ -80,6 +82,10 @@ bool areHolesEqual(const std::vector<std::vector<RNMapsGooglePolygonHolesStruct>
     // fewer than 3 points crashes Google Maps (null-deref in gmssdk::CoordsToPoints
     // during setMap:). Remember the target map and attach from attachIfReady — here
     // if the path is already valid, otherwise from updateProps once coordinates land.
+    // Cancel a detach queued by a just-fired didRemoveFromMap: an unmount immediately
+    // followed by this re-mount (same view, same transaction) is a Fabric reorder,
+    // not a removal, so the overlay must stay attached (no detach/reattach churn).
+    _detachScheduled = NO;
     _pendingMap = map;
     [self attachIfReady];
 }
@@ -96,9 +102,21 @@ bool areHolesEqual(const std::vector<std::vector<RNMapsGooglePolygonHolesStruct>
 
 -(void) didRemoveFromMap
 {
-    _pendingMap = nil;
-    _view.map = nil;
-    _view = nil;
+    // Defer the detach by one runloop tick instead of detaching now. Fabric expresses
+    // a zIndex reorder as unmount-then-remount of the SAME view within one synchronous
+    // transaction; didInsertInMap clears _detachScheduled before this block runs, so a
+    // reorder leaves the overlay attached with its props intact (no vanish, and no stale
+    // fillColor when two overlays reorder at once). Only a genuine removal (no matching
+    // re-mount) reaches the detach. Full teardown still happens in prepareForRecycle.
+    _detachScheduled = YES;
+    __weak RNMapsGooglePolygonView *weakSelf = self;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        RNMapsGooglePolygonView *strongSelf = weakSelf;
+        if (strongSelf == nil || !strongSelf->_detachScheduled) return;
+        strongSelf->_detachScheduled = NO;
+        strongSelf->_pendingMap = nil;
+        strongSelf->_view.map = nil;
+    });
 }
 
 - (void) prepareContentView {
@@ -153,6 +171,9 @@ bool areHolesEqual(const std::vector<std::vector<RNMapsGooglePolygonHolesStruct>
     [super prepareForRecycle];
     static const auto defaultProps = std::make_shared<const RNMapsGooglePolygonProps>();
     _props = defaultProps;
+    _detachScheduled = NO;
+    _pendingMap = nil;
+    _view.map = nil;
     _view = nil;
 }
 

--- a/ios/AirGoogleMaps/RNMapsGooglePolygonView.mm
+++ b/ios/AirGoogleMaps/RNMapsGooglePolygonView.mm
@@ -55,10 +55,12 @@ bool areHolesEqual(const std::vector<std::vector<RNMapsGooglePolygonHolesStruct>
 }
 
 @interface RNMapsGooglePolygonView () <RCTRNMapsGooglePolygonViewProtocol>
+- (void) attachIfReady;
 @end
 
 @implementation RNMapsGooglePolygonView {
     AIRGMSPolygon *_view;
+    __weak AIRGoogleMap *_pendingMap;
 }
 
 
@@ -73,11 +75,28 @@ bool areHolesEqual(const std::vector<std::vector<RNMapsGooglePolygonHolesStruct>
 
 - (void) didInsertInMap:(AIRGoogleMap*) map
 {
-    _view.map = map;
+    // Defer the attach until the path is renderable. Under Fabric the coordinates
+    // (props) can arrive AFTER mount, and attaching a GMSPolygon whose path has
+    // fewer than 3 points crashes Google Maps (null-deref in gmssdk::CoordsToPoints
+    // during setMap:). Remember the target map and attach from attachIfReady — here
+    // if the path is already valid, otherwise from updateProps once coordinates land.
+    _pendingMap = map;
+    [self attachIfReady];
+}
+
+// Attach to the map only when the polygon has a renderable path. Idempotent: safe
+// to call from both didInsertInMap and updateProps.
+- (void) attachIfReady
+{
+    if (_view != nil && _view.map == nil && _pendingMap != nil
+        && _view.path != nil && _view.path.count >= 3) {
+        _view.map = _pendingMap;
+    }
 }
 
 -(void) didRemoveFromMap
 {
+    _pendingMap = nil;
     _view.map = nil;
     _view = nil;
 }
@@ -209,6 +228,10 @@ bool areHolesEqual(const std::vector<std::vector<RNMapsGooglePolygonHolesStruct>
     if (newViewProps.strokeWidth != oldViewProps.strokeWidth){
         _view.strokeWidth = newViewProps.strokeWidth;
     }
+
+    // Coordinates may have just been applied above; attach now if the mount was
+    // deferred while the path was still empty.
+    [self attachIfReady];
 
   [super updateProps:props oldProps:oldProps];
 }


### PR DESCRIPTION
Fixes #5930

> **Depends on #5935** — this branch is on top of that fix, so its commit appears here too. Review/merge #5935 first; the net new change in this PR is the deferred detach in `didRemoveFromMap`.

## Problem
On the New Architecture (iOS, `provider="google"`), changing an overlay's `zIndex` makes it (and sometimes others) vanish. When two overlays change zIndex in the same commit, the demoted one can keep a stale `fillColor`.

## Cause
A `zIndex` change makes Fabric reorder the overlay children by unmounting and re-mounting the same view. `didRemoveFromMap` detaches the `GMSPolygon` immediately (and a pure reorder doesn't re-deliver props), so the overlay stays detached after the reorder.

## Fix
Defer the detach by one runloop tick; `didInsertInMap` cancels it when the same view is re-mounted in the same (synchronous) transaction — i.e. a reorder leaves the overlay attached. Only a genuine removal (no matching re-mount) detaches; `prepareForRecycle` does the real teardown and clears the pending flag. GMS draw order is already handled by `GMSPolygon.zIndex` in `updateProps`, so no view teardown is needed for a reorder.

Verified in an app against 1.27.2; raising/selecting overlays no longer drops them. Can't build-verify in-repo — please run CI / a device check.
