### PR TITLE
fix(Android): paint and remove New-Arch Polygon/Polyline overlays reliably (subset of #5932)

### DIFF
--- a/android/src/main/java/com/rnmaps/fabric/PolygonManager.java
+++ b/android/src/main/java/com/rnmaps/fabric/PolygonManager.java
@@ -40,6 +40,15 @@ public class PolygonManager extends ViewGroupManager<MapPolygon> implements RNMa
         return new MapPolygon(context);
     }
 
+    @Override
+    public void onDropViewInstance(MapPolygon view) {
+        // Identity-based overlay removal when Fabric drops/recycles the view, so a
+        // removed overlay can't linger as a "ghost" under the New Architecture (the
+        // index-based removeFeatureAt path is unreliable for batches).
+        view.removeFromMapDirectly();
+        super.onDropViewInstance(view);
+    }
+
 
 
     public static final String REACT_CLASS = "RNMapsGooglePolygon";

--- a/android/src/main/java/com/rnmaps/fabric/PolylineManager.java
+++ b/android/src/main/java/com/rnmaps/fabric/PolylineManager.java
@@ -50,6 +50,13 @@ public class PolylineManager extends ViewGroupManager<MapPolyline> implements RN
         return new MapPolyline(context);
     }
 
+    @Override
+    public void onDropViewInstance(MapPolyline view) {
+        // Identity-based overlay removal — see PolygonManager#onDropViewInstance.
+        view.removeFromMapDirectly();
+        super.onDropViewInstance(view);
+    }
+
 
     public static final String REACT_CLASS = "RNMapsPolyline";
 

--- a/android/src/main/java/com/rnmaps/maps/MapPolygon.java
+++ b/android/src/main/java/com/rnmaps/maps/MapPolygon.java
@@ -218,7 +218,33 @@ public class MapPolygon extends MapFeature {
 
   @Override
   public void removeFromMap(Object collection) {
+    if (polygon == null) return;
     PolygonManager.Collection polygonCollection = (PolygonManager.Collection) collection;
     polygonCollection.remove(polygon);
+    polygon = null;
+  }
+
+  /**
+   * Re-commit the (unchanged) points to force the GoogleMap surface to composite the
+   * overlay. Under the New Architecture a freshly-added polygon is not painted until a
+   * property mutates; re-applying its points triggers that paint with no visual or
+   * state change. Called from MapView on map-load and when the camera settles.
+   */
+  public void forceRedraw() {
+    if (polygon != null) {
+      polygon.setPoints(polygon.getPoints());
+    }
+  }
+
+  /**
+   * Remove this polygon's GoogleMap overlay directly, by identity. Called from
+   * PolygonManager#onDropViewInstance when Fabric drops/recycles the view, so removal
+   * doesn't depend on the index-based removeFeatureAt path (unreliable for batches).
+   */
+  public void removeFromMapDirectly() {
+    if (polygon != null) {
+      polygon.remove();
+      polygon = null;
+    }
   }
 }

--- a/android/src/main/java/com/rnmaps/maps/MapPolyline.java
+++ b/android/src/main/java/com/rnmaps/maps/MapPolyline.java
@@ -189,8 +189,25 @@ public class MapPolyline extends MapFeature {
 
     @Override
     public void removeFromMap(Object collection) {
+        if (polyline == null) return;
         PolylineManager.Collection polylineCollection = (PolylineManager.Collection) collection;
         polylineCollection.remove(polyline);
+        polyline = null;
+    }
+
+    /** Re-commit the points to force a New-Arch composite. See MapPolygon#forceRedraw. */
+    public void forceRedraw() {
+        if (polyline != null) {
+            polyline.setPoints(polyline.getPoints());
+        }
+    }
+
+    /** Remove this polyline's overlay by identity. See MapPolygon#removeFromMapDirectly. */
+    public void removeFromMapDirectly() {
+        if (polyline != null) {
+            polyline.remove();
+            polyline = null;
+        }
     }
 
     public void setLineCap(String lineCap) {

--- a/android/src/main/java/com/rnmaps/maps/MapView.java
+++ b/android/src/main/java/com/rnmaps/maps/MapView.java
@@ -685,10 +685,17 @@ public class MapView extends com.google.android.gms.maps.MapView implements Goog
             LatLngBounds bounds = map.getProjection().getVisibleRegion().latLngBounds;
             WritableMap payload = OnRegionChangeEvent.payLoadFor(bounds, isGesture);
             dispatchEvent(payload, OnRegionChangeCompleteEvent::new);
+            // New-Arch overlays stop painting during a camera move and won't repaint
+            // unchanged shapes until a property mutates — re-commit them once settled.
+            redrawAllOverlays();
         });
 
         map.setOnMapLoadedCallback(() -> {
             isMapLoaded = true;
+            // Overlays added before the surface finished loading (the common case on
+            // first open) are committed but not painted under the New Arch until a
+            // property mutates. Now that the map is loaded, re-commit them all.
+            redrawAllOverlays();
             dispatchEvent(new WritableNativeMap(), OnMapLoadedEvent::new);
             MapView.this.cacheView();
         });
@@ -1222,6 +1229,9 @@ public class MapView extends com.google.android.gms.maps.MapView implements Goog
             safeAddFeature(index, polylineView);
             Polyline polyline = (Polyline) polylineView.getFeature();
             polylineMap.put(polyline, polylineView);
+            // New-Arch overlays don't composite until a property mutates — nudge on
+            // the next frame, once this add is committed. See MapPolyline#forceRedraw.
+            post(polylineView::forceRedraw);
         } else if (child instanceof MapGradientPolyline) {
             MapGradientPolyline polylineView = (MapGradientPolyline) child;
             polylineView.addToMap(map);
@@ -1234,6 +1244,9 @@ public class MapView extends com.google.android.gms.maps.MapView implements Goog
             safeAddFeature(index, polygonView);
             Polygon polygon = (Polygon) polygonView.getFeature();
             polygonMap.put(polygon, polygonView);
+            // New-Arch overlays don't composite until a property mutates — nudge on
+            // the next frame, once this add is committed. See MapPolygon#forceRedraw.
+            post(polygonView::forceRedraw);
         } else if (child instanceof MapCircle) {
             MapCircle circleView = (MapCircle) child;
             circleView.addToMap(circleCollection);
@@ -1269,6 +1282,22 @@ public class MapView extends com.google.android.gms.maps.MapView implements Goog
             }
         } else {
             addView(child, index);
+        }
+    }
+
+    /**
+     * Re-commit every polygon/polyline overlay so the GoogleMap surface paints it.
+     * Under the New Architecture overlays added before the surface is ready (or while
+     * the camera is moving) stay invisible until a property mutates (markers are
+     * unaffected). Called once the map loads and again whenever the camera settles.
+     */
+    public void redrawAllOverlays() {
+        for (MapFeature feature : features) {
+            if (feature instanceof MapPolygon) {
+                ((MapPolygon) feature).forceRedraw();
+            } else if (feature instanceof MapPolyline) {
+                ((MapPolyline) feature).forceRedraw();
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #5932 (partial — focused subset)

## Problem
On the New Architecture (Android, `provider="google"`), `<Polygon>` / `<Polyline>` / `<Geojson>` overlays:
- often don't paint until a property mutates or the user zooms,
- aren't repainted after a camera move, and
- can linger ("ghost") on removal.

Markers are unaffected.

## Fix (focused subset)
- **Paint:** re-commit overlays (re-apply their points — visually a no-op) on map-load and on camera-idle, and nudge each newly added overlay on the next frame, so they paint without needing a zoom. (`MapView.redrawAllOverlays`, `MapPolygon`/`MapPolyline.forceRedraw`)
- **Removal:** remove the overlay by identity when Fabric drops/recycles the view (`PolygonManager`/`PolylineManager.onDropViewInstance` → `removeFromMapDirectly`), instead of relying solely on the index-based `removeFeatureAt` path (unreliable for batches under Fabric).

## Scope / caveats
- This is a **subset** of the full fix for #5932. It deliberately omits a `visible`-prop / deterministic `overlayReconcileJSON` backstop, because those require **spec + codegen** changes; this PR stays within the hand-editable Java so it's easy to review.
- **Not build-verified in this repo** — the changes are ported from a working `patch-package` patch validated in an app against 1.27.2 (the same source as `master`). Please run CI / a device check.
