### PR TITLE
fix(ios): replace RCTImageLoader with NSURLSession for bridgeless mode compatibility (#5912)

### DIFF
--- a/ios/AirMaps/AIRMapMarker.h
+++ b/ios/AirMaps/AIRMapMarker.h
@@ -18,13 +18,10 @@
 #import "SMCalloutView.h"
 #import "RCTConvert+AirMap.h"
 
-@class RCTBridge;
-
 @interface AIRMapMarker : MKAnnotationView <MKAnnotation>
 
 @property (nonatomic, strong) AIRMapCallout *calloutView;
 @property (nonatomic, weak) AIRMap *map;
-@property (nonatomic, weak) RCTBridge *bridge;
 
 @property (nonatomic, strong) NSString *identifier;
 @property (nonatomic, copy) NSString *imageSrc;

--- a/ios/AirMaps/AIRMapMarker.m
+++ b/ios/AirMaps/AIRMapMarker.m
@@ -9,22 +9,78 @@
 
 #import "AIRMapMarker.h"
 
-#import <React/RCTBridge.h>
-#import <React/RCTEventDispatcher.h>
-#import <React/RCTImageLoaderProtocol.h>
 #import <React/RCTUtils.h>
 #import <React/UIView+React.h>
-#import <React/RCTImageLoader.h>
-#import <React/RCTBridge+Private.h>
 
 NSInteger const AIR_CALLOUT_OPEN_ZINDEX_BASELINE = 999;
+
+// ---------------------------------------------------------------------------
+// Image loading — coalescing cache
+//
+// Multiple markers sharing the same image URL (common case: all markers use
+// the same pin asset) would each fire an independent NSURLSession request
+// without this. The coalescer ensures exactly one in-flight request per URL.
+// All callers that arrive while a request is in-flight are queued and notified
+// together when it completes. Results are cached in memory for the process
+// lifetime so subsequent mounts are instant.
+//
+// All access to these dictionaries happens on the main thread:
+//   - setImageSrc: is called from React Native's UI thread
+//   - the NSURLSession completion block dispatches back to the main queue
+// ---------------------------------------------------------------------------
+static NSCache<NSString *, UIImage *>                                          *AIRImageCache;
+static NSMutableDictionary<NSString *, NSMutableArray<void (^)(UIImage *)> *>  *AIRPendingHandlers;
+
+// Requests the image at urlString, returning a cancel block.
+// "Cancel" means this caller no longer wants the result — it does NOT abort
+// the network request, which other waiting callers still need.
+static dispatch_block_t AIRLoadImage(NSString *urlString, CGFloat scale, void (^completion)(UIImage *)) {
+    if (!AIRImageCache)      AIRImageCache      = [NSCache new];
+    if (!AIRPendingHandlers) AIRPendingHandlers = [NSMutableDictionary new];
+
+    // Cache hit — deliver on next run-loop tick so callers always get async behaviour
+    UIImage *cached = [AIRImageCache objectForKey:urlString];
+    if (cached) {
+        dispatch_async(dispatch_get_main_queue(), ^{ completion(cached); });
+        return ^{};
+    }
+
+    // Coalesce: register callback and let the existing in-flight request deliver it
+    __block BOOL cancelled = NO;
+    void (^handler)(UIImage *) = ^(UIImage *image) { if (!cancelled) completion(image); };
+
+    NSMutableArray *handlers = AIRPendingHandlers[urlString];
+    if (handlers) {
+        [handlers addObject:handler];
+        return ^{ cancelled = YES; };
+    }
+
+    // First request for this URL
+    AIRPendingHandlers[urlString] = [NSMutableArray arrayWithObject:handler];
+
+    NSURL *url = [NSURL URLWithString:urlString];
+    [[[NSURLSession sharedSession]
+        dataTaskWithURL:url
+      completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+        UIImage *image = (!error && data) ? [UIImage imageWithData:data scale:scale] : nil;
+        if (!image) NSLog(@"AIRMapMarker failed to load image: %@", error);
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (image) [AIRImageCache setObject:image forKey:urlString];
+            NSArray *pending = AIRPendingHandlers[urlString];
+            [AIRPendingHandlers removeObjectForKey:urlString];
+            for (void (^h)(UIImage *) in pending) h(image);
+        });
+    }] resume];
+
+    return ^{ cancelled = YES; };
+}
 
 @implementation AIREmptyCalloutBackgroundView
 @end
 
 @implementation AIRMapMarker {
     BOOL _hasSetCalloutOffset;
-    RCTImageLoaderCancellationBlock _reloadImageCancellationBlock;
+    dispatch_block_t _imageLoadCancel;
     MKMarkerAnnotationView *_markerView;
     MKPinAnnotationView *_pinView;
     BOOL _calloutIsOpen;
@@ -362,29 +418,17 @@ NSInteger const AIR_CALLOUT_OPEN_ZINDEX_BASELINE = 999;
 {
     _imageSrc = imageSrc;
 
-    if (_reloadImageCancellationBlock) {
-        _reloadImageCancellationBlock();
-        _reloadImageCancellationBlock = nil;
+    // Deregister from any previous in-flight load
+    if (_imageLoadCancel) {
+        _imageLoadCancel();
+        _imageLoadCancel = nil;
     }
-    __weak __typeof(self) weakSelf = self;
+    if (!imageSrc) return;
 
-    _reloadImageCancellationBlock = [[[RCTBridge currentBridge] moduleForName:@"ImageLoader"] loadImageWithURLRequest:[RCTConvert NSURLRequest:_imageSrc]
-                                                                                                                 size:self.bounds.size
-                                                                                                                scale:RCTScreenScale()
-                                                                                                              clipped:YES
-                                                                                                           resizeMode:RCTResizeModeCenter
-                                                                                                        progressBlock:nil
-                                                                                                     partialLoadBlock:nil
-                                                                                                      completionBlock:^(NSError *error, UIImage *image) {
-        if (error) {
-            // TODO(lmr): do something with the error?
-            NSLog(@"failed to load image: %@", error);
-        }
-        dispatch_async(dispatch_get_main_queue(), ^{
-            __strong __typeof(weakSelf) strongSelf = weakSelf;
-            strongSelf.image = image;
-        });
-    }];
+    __weak __typeof(self) weakSelf = self;
+    _imageLoadCancel = AIRLoadImage(imageSrc, RCTScreenScale(), ^(UIImage *image) {
+        weakSelf.image = image;
+    });
 }
 
 - (void)setPinColor:(UIColor *)pinColor

--- a/ios/AirMaps/AIRMapMarker.m
+++ b/ios/AirMaps/AIRMapMarker.m
@@ -31,13 +31,34 @@ NSInteger const AIR_CALLOUT_OPEN_ZINDEX_BASELINE = 999;
 static NSCache<NSString *, UIImage *>                                          *AIRImageCache;
 static NSMutableDictionary<NSString *, NSMutableArray<void (^)(UIImage *)> *>  *AIRPendingHandlers;
 
+// True for URIs that came out of RN's asset pipeline rather than an arbitrary
+// remote URL: an on-device bundled asset (file:// under the app's bundle,
+// library, or home directory — what RCTIsLocalAssetURL already recognizes
+// for RN's own image loaders) or the Metro dev-server form produced by
+// AssetSourceResolver's assetServerURL(), e.g. ".../assets/Foo/icon@2x.png
+// ?platform=ios&hash=...".
+static BOOL AIRIsPackagerAssetURL(NSURL *url) {
+    if (RCTIsLocalAssetURL(url)) {
+        return YES;
+    }
+    NSString *query = url.query;
+    return url.path != nil && [url.path containsString:@"/assets/"]
+        && query != nil && [query containsString:@"hash="];
+}
+
 // React Native's asset resolver bakes the chosen density into the filename
 // (e.g. "pin@2x.png"), omitting the suffix for 1x. That resolved density is
-// what the pixel data actually is, so it — not the screen's scale — is what
-// UIImage must be decoded with.
+// what the pixel data actually is, so for RN assets it — not the screen's
+// scale — is what UIImage must be decoded with. Arbitrary remote URLs carry
+// no such baked-in density, so they keep using the screen's scale as before.
 static CGFloat AIRScaleFromAssetURL(NSString *urlString) {
+    NSURL *url = [NSURL URLWithString:urlString];
+    if (!AIRIsPackagerAssetURL(url)) {
+        return RCTScreenScale();
+    }
+
     CGFloat scale = 1;
-    NSString *filename = [NSURL URLWithString:urlString].path.lastPathComponent;
+    NSString *filename = url.path.lastPathComponent;
     NSRange at = [filename rangeOfString:@"@" options:NSBackwardsSearch];
     if (at.location != NSNotFound) {
         NSString *suffix = [filename substringFromIndex:at.location + 1];
@@ -445,6 +466,15 @@ static dispatch_block_t AIRLoadImage(NSString *urlString, CGFloat scale, void (^
         _imageLoadCancel = nil;
     }
     if (!imageSrc) return;
+
+    // A bare name with no URL scheme (e.g. image={{uri: 'custom_pin'}}) refers
+    // to an Xcode asset-catalog image, not something NSURLSession can fetch.
+    // Load it synchronously via the catalog instead, as RCTLocalAssetImageLoader
+    // did before this component moved off RCTImageLoader.
+    if ([NSURL URLWithString:imageSrc].scheme == nil) {
+        self.image = [UIImage imageNamed:imageSrc];
+        return;
+    }
 
     __weak __typeof(self) weakSelf = self;
     _imageLoadCancel = AIRLoadImage(imageSrc, AIRScaleFromAssetURL(imageSrc), ^(UIImage *image) {

--- a/ios/AirMaps/AIRMapMarker.m
+++ b/ios/AirMaps/AIRMapMarker.m
@@ -31,6 +31,27 @@ NSInteger const AIR_CALLOUT_OPEN_ZINDEX_BASELINE = 999;
 static NSCache<NSString *, UIImage *>                                          *AIRImageCache;
 static NSMutableDictionary<NSString *, NSMutableArray<void (^)(UIImage *)> *>  *AIRPendingHandlers;
 
+// React Native's asset resolver bakes the chosen density into the filename
+// (e.g. "pin@2x.png"), omitting the suffix for 1x. That resolved density is
+// what the pixel data actually is, so it — not the screen's scale — is what
+// UIImage must be decoded with.
+static CGFloat AIRScaleFromAssetURL(NSString *urlString) {
+    CGFloat scale = 1;
+    NSString *filename = [NSURL URLWithString:urlString].path.lastPathComponent;
+    NSRange at = [filename rangeOfString:@"@" options:NSBackwardsSearch];
+    if (at.location != NSNotFound) {
+        NSString *suffix = [filename substringFromIndex:at.location + 1];
+        NSRange x = [suffix rangeOfString:@"x"];
+        if (x.location != NSNotFound) {
+            CGFloat parsed = [[suffix substringToIndex:x.location] doubleValue];
+            if (parsed > 0) {
+                scale = parsed;
+            }
+        }
+    }
+    return scale;
+}
+
 // Requests the image at urlString, returning a cancel block.
 // "Cancel" means this caller no longer wants the result — it does NOT abort
 // the network request, which other waiting callers still need.
@@ -426,7 +447,7 @@ static dispatch_block_t AIRLoadImage(NSString *urlString, CGFloat scale, void (^
     if (!imageSrc) return;
 
     __weak __typeof(self) weakSelf = self;
-    _imageLoadCancel = AIRLoadImage(imageSrc, RCTScreenScale(), ^(UIImage *image) {
+    _imageLoadCancel = AIRLoadImage(imageSrc, AIRScaleFromAssetURL(imageSrc), ^(UIImage *image) {
         weakSelf.image = image;
     });
 }

--- a/ios/AirMaps/AIRMapMarkerManager.m
+++ b/ios/AirMaps/AIRMapMarkerManager.m
@@ -26,7 +26,6 @@ RCT_EXPORT_MODULE()
 {
     AIRMapMarker *marker = [AIRMapMarker new];
     [marker addTapGestureRecognizer];
-    marker.bridge = self.bridge;
     marker.isAccessibilityElement = YES;
     marker.accessibilityElementsHidden = NO;
     return marker;


### PR DESCRIPTION
### Does any other open PR do the same thing?
No

### What issue is this PR fixing?
In bridgeless mode (New Architecture, RN >= 0.82), `[RCTBridge currentBridge]`
returns `nil`, causing marker images to silently fail to load. This affects any
app running the New Architecture with image-based markers.

Fixes #5912

### Solution

Replace the `RCTImageLoader`-based image loading in `AIRMapMarker` with a
standalone `NSURLSession` implementation.

The image URI is already fully resolved by the JS side before it reaches native
(local assets become `file://` URIs, Metro dev server assets become
`http://localhost:8081/...` URIs), so `RCTImageLoader` is not needed.

The replacement implementation:
- Uses `NSURLSession` directly to fetch the resolved URI
- Coalesces concurrent requests for the same URL so multiple markers sharing
  one image asset fire only a single network request
- Caches results in an `NSCache`, which evicts automatically under memory
  pressure
- Cancellation removes the caller's interest without aborting the underlying
  request, which other waiting markers may still need

The now-unused `bridge` property is removed from `AIRMapMarker`.

### How did you test this PR?
- Platforms affected: Affects only iOS.
- Tested both on a simulator and on a real device.
- Stress tested with 10 000+ markers rendered on screen.

### Future work
The proper long-term fix is to migrate `AIRMapMarker` to a true Fabric native
component. Fabric components declare their props in a typed component spec and
receive images through the Fabric renderer's built-in image pipeline, the same
way React Native's own `<Image>` component works. This patch is a pragmatic fix
to unblock bridgeless mode users without the scope of a full Fabric migration.