### PR TITLE
fix(ios): guard Google Maps subview insertion

### DIFF
--- a/ios/AirGoogleMaps/AIRGoogleMap.mm
+++ b/ios/AirGoogleMaps/AIRGoogleMap.mm
@@ -245,6 +245,10 @@ id regionAsJSON(MKCoordinateRegion region) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wobjc-missing-super-calls"
 - (void)insertReactSubview:(id<RCTComponent>)subview atIndex:(NSInteger)atIndex {
+  if (subview == nil) {
+    return;
+  }
+
   // Our desired API is to pass up markers/overlays as children to the mapview component.
   // This is where we intercept them and do the appropriate underlying mapview action.
   if ([subview isKindOfClass:[AIRGoogleMapMarker class]]) {
@@ -290,7 +294,9 @@ id regionAsJSON(MKCoordinateRegion region) {
       [self insertReactSubview:(UIView *)childSubviews[i] atIndex:atIndex];
     }
   }
-  [_reactSubviews insertObject:(UIView *)subview atIndex:(NSUInteger) atIndex];
+  NSUInteger safeIndex = atIndex < 0 ? 0 : (NSUInteger)atIndex;
+  safeIndex = MIN(safeIndex, _reactSubviews.count);
+  [_reactSubviews insertObject:(UIView *)subview atIndex:safeIndex];
 }
 #pragma clang diagnostic pop
 


### PR DESCRIPTION
## Summary

Guard Google Maps iOS subview insertion against invalid native inputs before updating `_reactSubviews`.

This mirrors the defensive insertion behavior proposed for Apple Maps in #5871, but applies it to `ios/AirGoogleMaps/AIRGoogleMap.mm`, which is the crash path reported for Google Maps in #5217.

## Root cause

`insertReactSubview:atIndex:` inserted directly into `_reactSubviews` using the incoming `subview` and `atIndex`. When React Native passes a nil subview or an index outside the current array bounds during dynamic marker updates, NSMutableArray raises an exception.

## Changes

- Return early when `subview` is nil.
- Clamp `atIndex` into `[0, _reactSubviews.count]` before inserting.
- Keep the change limited to the Google Maps iOS implementation; no JS/API changes.

## Branch target

This PR targets `master` because the crash was validated against `react-native-maps@1.27.2`, and `master` currently represents that release line. If maintainers prefer this on `beta`, I can port the same guard to the v2 file layout under `ios/GoogleMaps/RNMGoogleMap.m`.

## Validation

- `yarn --frozen-lockfile`
- `yarn lint`
- `yarn tscheck`
- `yarn format-check`
- `yarn test`

I did not run the local iOS example build because this machine is missing the repo-locked Bundler version (`2.3.26`). Xcode and CocoaPods are installed, but I avoided changing the local Ruby setup just for this PR.

References #5217
Related #5871
