### PR TITLE
fix(ios): avoid full overlay rebuild on AIRMapUrlTile opacity change

### DIFF
--- a/ios/AirMaps/AIRMapUrlTile.m
+++ b/ios/AirMaps/AIRMapUrlTile.m
@@ -110,11 +110,14 @@
     _opacity = opacity;
     _opacitySet = YES;
     if (self.renderer) {
+        // Apply alpha in place. Calling [self update] here would remove and
+        // re-add the overlay (and every other overlay), causing the map to
+        // flash on every opacity change - e.g. when animating radar frames.
         self.renderer.alpha = opacity;
     } else {
         [self createTileOverlayAndRendererIfPossible];
+        [self update];
     }
-    [self update];
 }
 
 - (void)createTileOverlayAndRendererIfPossible


### PR DESCRIPTION
## Summary

`AIRMapUrlTile`'s opacity setter always called `[self update]`, which tears down and re-adds the `MKTileOverlay` (and re-evaluates every overlay on the map). When the `opacity` prop is animated - for example, cross-fading animated tile frames - this produced a visible flash on every opacity change.

## Change

When a renderer already exists, set `renderer.alpha` directly instead of rebuilding the overlay. `[self update]` is now only called on the path where the overlay/renderer must be created for the first time.

## Platform

- iOS only (`ios/AirMaps/AIRMapUrlTile.m`). No JS or Android changes.

## Testing

- Verified on a map with an animated `UrlTile` overlay whose `opacity` is driven on each frame; the per-frame flash is gone and tiles render continuously.
- Static opacity changes and initial tile creation still work (the create-then-update path is unchanged).