### PR TITLE
fix(ios): lay out Google custom marker views before attachment

### DIFF
--- a/ios/AirGoogleMaps/AIRGoogleMapMarker.m
+++ b/ios/AirGoogleMaps/AIRGoogleMapMarker.m
@@ -67,8 +67,10 @@ CGRect unionRect(CGRect a, CGRect b) {
 
     for (UIView *v in [_iconView subviews]) {
 
-        float fw = v.frame.origin.x + v.frame.size.width;
-        float fh = v.frame.origin.y + v.frame.size.height;
+        // frame includes a UIView transform. Custom markers can be scaled by
+        // Reanimated while entering, so use the stable layout bounds instead.
+        float fw = v.bounds.size.width;
+        float fh = v.bounds.size.height;
 
         width = MAX(fw, width);
         height = MAX(fh, height);
@@ -145,6 +147,10 @@ CGRect unionRect(CGRect a, CGRect b) {
     if (_zIndex){
         [_realMarker setZIndex:_zIndex];
     }
+    [self layoutSubviews];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self layoutSubviews];
+    });
     [_realMarker setMap:map];
 }
 
@@ -152,10 +158,16 @@ CGRect unionRect(CGRect a, CGRect b) {
     if (!_iconView){
         _iconView = [[UIView alloc] init];
     }
+    [_iconView insertSubview:subview atIndex:atIndex];
+    // Size _iconView to fit its children before setting it on the marker.
+    [self layoutSubviews];
     if (!_realMarker.iconView) {
         _realMarker.iconView = _iconView;
     }
-    [_iconView insertSubview:subview atIndex:atIndex];
+    // Fabric lays out children asynchronously, so measure once more next run loop.
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self layoutSubviews];
+    });
 }
 
 - (void)insertReactSubview:(id<RCTComponent>)subview atIndex:(NSInteger)atIndex {


### PR DESCRIPTION
## Summary

Fixes the iOS Google Maps custom-marker layout race introduced in 1.29.0.

- attaches a marker child before assigning the marker `iconView`
- lays out the icon view immediately and once on the next main-loop turn, after Fabric has completed child layout
- measures stable view bounds instead of a transient transformed frame, so Reanimated entrance transforms cannot produce a cropped marker snapshot

## Root cause

Under Fabric, custom marker children can be attached before their final layout is available. Google Maps then snapshots a zero or transform-scaled `iconView`; after `tracksViewChanges` is disabled, that invalid snapshot can disappear or render cropped while panning.

## Validation

- inspected against the 1.29.0 source used by the reproducer
- `git diff --check`

Fixes #5953
