### PR TITLE
feat(ios): add automatic SPM support for Google Maps via cocoapods-spm

### DIFF
--- a/.github/workflows/iosGoogleSPMBuild.yml
+++ b/.github/workflows/iosGoogleSPMBuild.yml
@@ -1,0 +1,38 @@
+name: iOS Google SPM build
+
+on:
+  pull_request:
+
+jobs:
+  build-ios-google-spm:
+    runs-on: macos-latest
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 'lts/*'
+          cache: yarn
+
+      - name: Setup ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2.2'
+          bundler-cache: true
+          working-directory: example
+
+      - name: Install dependencies
+        run: yarn --cwd example --frozen-lockfile
+
+      - name: Install pods
+        run: USE_GOOGLE_SPM=1 bundle exec pod install
+        working-directory: example/ios
+
+      - name: Write Secrets.xcconfig
+        run: echo MAPS_API_KEY=your_api_key_here >> example/ios/Secrets.xcconfig
+
+      - name: Build iOS
+        run: xcodebuild -workspace example/ios/rnmshowcase.xcworkspace -scheme rnmshowcase -configuration Debug -sdk iphonesimulator

--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,5 @@ Secrets.xcconfig
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+example/ios/.spm.pods

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -117,6 +117,10 @@ That's it, you made it! 👍
 
 Google is phasing out CocoaPods releases of the Google Maps Platform iOS SDKs. As an alternative to the `Google` subspec above, `GoogleSPM` resolves GoogleMaps/Google-Maps-iOS-Utils via [Swift Package Manager](https://www.swift.org/documentation/package-manager/) instead, using the [`cocoapods-spm`](https://github.com/trinhngocthuyen/cocoapods-spm) plugin so integration stays automatic through a normal `pod install` - no manual Xcode "Package Dependencies" step required.
 
+**Requirements:**
+
+- iOS deployment target **16.0 or higher**. GoogleMaps and Google-Maps-iOS-Utils versions published via SPM (10.x+ / 6.1.3+ respectively) require it - set this in your Podfile (`platform :ios, '16.0'`) and in your Xcode project's deployment target.
+
 Add the plugin to your `Gemfile`:
 
 ```ruby
@@ -126,6 +130,8 @@ gem 'cocoapods-spm'
 Then in your `Podfile`, declare the two package sources and select `GoogleSPM` instead of `Google`:
 
 ```ruby
+platform :ios, '16.0'
+
 spm_pkg 'GoogleMaps', :url => 'https://github.com/googlemaps/ios-maps-sdk', :version => '10.15.0'
 spm_pkg 'GoogleMapsUtils', :url => 'https://github.com/googlemaps/google-maps-ios-utils', :version => '6.1.3'
 
@@ -133,19 +139,19 @@ rn_maps_path = '../node_modules/react-native-maps'
 pod 'react-native-maps/GoogleSPM', :path => rn_maps_path
 ```
 
-Because `react-native-maps` is autolinked, also exclude it from iOS autolinking in `react-native.config.js` so autolinking doesn't also add a conflicting `react-native-maps` pod declaration:
+`react-native-maps` should stay autolinked as normal (do **not** exclude it in `react-native.config.js` the way you might for other native dependencies) - autolinking is also what registers this library's Fabric components, so excluding it breaks map rendering with an `Unimplemented component: <RNMapsGoogleMapView>` error even though the native build succeeds.
 
-```js
-module.exports = {
-  dependencies: {
-    'react-native-maps': {
-      platforms: {ios: null},
-    },
-  },
-};
+**AppDelegate:** `cocoapods-spm` links the GoogleMaps package to this library's own pod target, not to your app's target directly - attaching it there too would duplicate GoogleMaps' bundled resources and fail the build. So instead of importing `<GoogleMaps/GoogleMaps.h>` and calling `[GMSServices provideAPIKey:...]` from your `AppDelegate.m(m)` as shown above, do this instead:
+
+```diff
+-#import <GoogleMaps/GoogleMaps.h>
++#import <ReactNativeMaps/AIRGMSServicesProvider.h>
+
+ ...
+
+-[GMSServices provideAPIKey:@"_YOUR_API_KEY_"];
++[AIRGMSServicesProvider provideAPIKey:@"_YOUR_API_KEY_"];
 ```
-
-**Known limitation:** the Heatmap component (`<Heatmap />`) is not available through the `GoogleSPM` subspec. The Google-Maps-iOS-Utils versions published via SPM (6.1.3+) rewrote Heatmap in Swift and dropped the Objective-C `GMUHeatmapTileLayer` API this wrapper's Heatmap component depends on. Apps that use `<Heatmap />` should stay on the `Google` subspec until Heatmap is ported to the new API.
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -153,6 +153,19 @@ pod 'react-native-maps/GoogleSPM', :path => rn_maps_path
 +[AIRGMSServicesProvider provideAPIKey:@"_YOUR_API_KEY_"];
 ```
 
+If your `AppDelegate` is Swift, `import ReactNativeMaps` (even just from a bridging header) makes Swift build a full Clang module for it, which transitively pulls in React's C++-heavy Fabric/JSI headers and can fail depending on your project's settings. Forward-declare the plain C entry point in your bridging header instead, and call that:
+
+```c
+// YourApp-Bridging-Header.h
+extern void RNMapsProvideGoogleMapsAPIKey(const char *_Nonnull apiKey);
+```
+
+```swift
+RNMapsProvideGoogleMapsAPIKey(apiKey)
+```
+
+**Trying it out:** the `example/` app in this repo can be built against `GoogleSPM` by setting `USE_GOOGLE_SPM=1` before `pod install` (its `AppDelegate.swift` and `Podfile` already branch on this), without disturbing its default `Google` configuration.
+
 ---
 
 ## Android

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -113,6 +113,40 @@ The app's Info.plist file must contain a NSLocationWhenInUseUsageDescription wit
 
 That's it, you made it! 👍
 
+### Enabling Google Maps via Swift Package Manager (experimental)
+
+Google is phasing out CocoaPods releases of the Google Maps Platform iOS SDKs. As an alternative to the `Google` subspec above, `GoogleSPM` resolves GoogleMaps/Google-Maps-iOS-Utils via [Swift Package Manager](https://www.swift.org/documentation/package-manager/) instead, using the [`cocoapods-spm`](https://github.com/trinhngocthuyen/cocoapods-spm) plugin so integration stays automatic through a normal `pod install` - no manual Xcode "Package Dependencies" step required.
+
+Add the plugin to your `Gemfile`:
+
+```ruby
+gem 'cocoapods-spm'
+```
+
+Then in your `Podfile`, declare the two package sources and select `GoogleSPM` instead of `Google`:
+
+```ruby
+spm_pkg 'GoogleMaps', :url => 'https://github.com/googlemaps/ios-maps-sdk', :version => '10.15.0'
+spm_pkg 'GoogleMapsUtils', :url => 'https://github.com/googlemaps/google-maps-ios-utils', :version => '6.1.3'
+
+rn_maps_path = '../node_modules/react-native-maps'
+pod 'react-native-maps/GoogleSPM', :path => rn_maps_path
+```
+
+Because `react-native-maps` is autolinked, also exclude it from iOS autolinking in `react-native.config.js` so autolinking doesn't also add a conflicting `react-native-maps` pod declaration:
+
+```js
+module.exports = {
+  dependencies: {
+    'react-native-maps': {
+      platforms: {ios: null},
+    },
+  },
+};
+```
+
+**Known limitation:** the Heatmap component (`<Heatmap />`) is not available through the `GoogleSPM` subspec. The Google-Maps-iOS-Utils versions published via SPM (6.1.3+) rewrote Heatmap in Swift and dropped the Objective-C `GMUHeatmapTileLayer` API this wrapper's Heatmap component depends on. Apps that use `<Heatmap />` should stay on the `Google` subspec until Heatmap is ported to the new API.
+
 ---
 
 ## Android

--- a/example/Gemfile
+++ b/example/Gemfile
@@ -5,6 +5,7 @@ ruby ">= 2.6.10"
 
 # Exclude problematic versions of cocoapods and activesupport that causes build failures.
 gem 'cocoapods', '>= 1.13', '!= 1.15.0', '!= 1.15.1'
+gem 'cocoapods-spm', '~> 0.1.20'
 gem 'activesupport', '>= 6.1.7.5', '!= 7.1.0'
 gem 'xcodeproj', '< 1.26.0'
 gem 'concurrent-ruby', '< 1.3.4'

--- a/example/Gemfile.lock
+++ b/example/Gemfile.lock
@@ -54,6 +54,8 @@ GEM
     cocoapods-plugins (1.0.0)
       nap
     cocoapods-search (1.0.1)
+    cocoapods-spm (0.1.20)
+      xcodeproj (>= 1.23.0)
     cocoapods-trunk (1.6.0)
       nap (>= 0.8, < 2.0)
       netrc (~> 0.11)
@@ -104,6 +106,7 @@ DEPENDENCIES
   benchmark
   bigdecimal
   cocoapods (>= 1.13, != 1.15.1, != 1.15.0)
+  cocoapods-spm (~> 0.1.20)
   concurrent-ruby (< 1.3.4)
   logger
   mutex_m

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -5,13 +5,22 @@ require Pod::Executable.execute_command('node', ['-p',
     {paths: [process.argv[1]]},
   )', __dir__]).strip
 
-platform :ios, '15.1'
+# Set USE_GOOGLE_SPM=1 to test the GoogleSPM subspec instead of the default
+# Google (CocoaPods) one.
+use_google_spm = ENV['USE_GOOGLE_SPM'] == '1'
+
+# GoogleMaps/Google-Maps-iOS-Utils published via SPM require iOS 16.
+platform :ios, use_google_spm ? '16.0' : '15.1'
 prepare_react_native_project!
 
 linkage = ENV['USE_FRAMEWORKS']
 if linkage != nil
   Pod::UI.puts "Configuring Pod with #{linkage}ally linked Frameworks".green
   use_frameworks! :linkage => linkage.to_sym
+elsif use_google_spm
+  # Static linkage, not the dynamic default, is what links GoogleMaps'
+  # symbols into react-native-maps' own framework.
+  use_frameworks! :linkage => :static
 end
 
 target 'rnmshowcase' do
@@ -24,7 +33,13 @@ target 'rnmshowcase' do
 
   rn_maps_path = '../..'
 
-  pod 'react-native-maps/Google', :path => rn_maps_path
+  if use_google_spm
+    spm_pkg 'GoogleMaps', :url => 'https://github.com/googlemaps/ios-maps-sdk', :version => '10.15.0'
+    spm_pkg 'GoogleMapsUtils', :url => 'https://github.com/googlemaps/google-maps-ios-utils', :version => '6.1.3'
+    pod 'react-native-maps/GoogleSPM', :path => rn_maps_path
+  else
+    pod 'react-native-maps/Google', :path => rn_maps_path
+  end
 
   post_install do |installer|
     react_native_post_install(
@@ -33,5 +48,21 @@ target 'rnmshowcase' do
       :mac_catalyst_enabled => false,
     )
 
+    if use_google_spm
+      user_project = installer.aggregate_targets.first.user_project
+      target = user_project.targets.find { |t| t.name == 'rnmshowcase' }
+      if target
+        target.build_configurations.each do |config|
+          existing = config.build_settings['SWIFT_ACTIVE_COMPILATION_CONDITIONS'] || '$(inherited)'
+          unless existing.split(' ').include?('USE_GOOGLE_SPM')
+            config.build_settings['SWIFT_ACTIVE_COMPILATION_CONDITIONS'] = "#{existing} USE_GOOGLE_SPM"
+          end
+          config.build_settings['SWIFT_OBJC_BRIDGING_HEADER'] = 'rnmshowcase/rnmshowcase-Bridging-Header.h'
+          # `platform :ios` above only governs the Pods, not this target.
+          config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '16.0'
+        end
+      end
+      user_project.save
+    end
   end
 end

--- a/example/ios/rnmshowcase/AppDelegate.swift
+++ b/example/ios/rnmshowcase/AppDelegate.swift
@@ -3,7 +3,10 @@ import React
 import React_RCTAppDelegate
 import ReactAppDependencyProvider
 
+#if !USE_GOOGLE_SPM
 import GoogleMaps
+#endif
+// RNMapsProvideGoogleMapsAPIKey is forward-declared in the bridging header.
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -17,7 +20,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
   ) -> Bool {
       if let MAPS_API_KEY = Bundle.main.object(forInfoDictionaryKey: "MAPS_API_KEY") as? String {
+#if USE_GOOGLE_SPM
+          RNMapsProvideGoogleMapsAPIKey(MAPS_API_KEY)
+#else
           GMSServices.provideAPIKey(MAPS_API_KEY)
+#endif
       }
     let delegate = ReactNativeDelegate()
     let factory = RCTReactNativeFactory(delegate: delegate)

--- a/example/ios/rnmshowcase/rnmshowcase-Bridging-Header.h
+++ b/example/ios/rnmshowcase/rnmshowcase-Bridging-Header.h
@@ -1,0 +1,4 @@
+// Only used when USE_GOOGLE_SPM=1. `#import <ReactNativeMaps/...>` would
+// make Swift build a full Clang module and fail on its C++ headers, so this
+// forward-declares the plain C entry point instead.
+extern void RNMapsProvideGoogleMapsAPIKey(const char *_Nonnull apiKey);

--- a/ios/AirGoogleMaps/AIRGMSServicesProvider.h
+++ b/ios/AirGoogleMaps/AIRGMSServicesProvider.h
@@ -7,3 +7,13 @@
 + (void)provideAPIKey:(NSString *)apiKey;
 
 @end
+
+// Plain C entry point for Swift AppDelegates, where `import ReactNativeMaps`
+// can fail to build (see docs/installation.md).
+#ifdef __cplusplus
+extern "C" {
+#endif
+void RNMapsProvideGoogleMapsAPIKey(const char *_Nonnull apiKey);
+#ifdef __cplusplus
+}
+#endif

--- a/ios/AirGoogleMaps/AIRGMSServicesProvider.h
+++ b/ios/AirGoogleMaps/AIRGMSServicesProvider.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+
+// Lets consuming apps call GMSServices.provideAPIKey without linking the
+// GoogleMaps SPM package to their own target.
+@interface AIRGMSServicesProvider : NSObject
+
++ (void)provideAPIKey:(NSString *)apiKey;
+
+@end

--- a/ios/AirGoogleMaps/AIRGMSServicesProvider.m
+++ b/ios/AirGoogleMaps/AIRGMSServicesProvider.m
@@ -1,0 +1,11 @@
+#import "AIRGMSServicesProvider.h"
+#import <GoogleMaps/GoogleMaps.h>
+
+@implementation AIRGMSServicesProvider
+
++ (void)provideAPIKey:(NSString *)apiKey
+{
+  [GMSServices provideAPIKey:apiKey];
+}
+
+@end

--- a/ios/AirGoogleMaps/AIRGMSServicesProvider.m
+++ b/ios/AirGoogleMaps/AIRGMSServicesProvider.m
@@ -9,3 +9,8 @@
 }
 
 @end
+
+void RNMapsProvideGoogleMapsAPIKey(const char *apiKey)
+{
+  [AIRGMSServicesProvider provideAPIKey:[NSString stringWithUTF8String:apiKey]];
+}

--- a/ios/AirGoogleMaps/AIRGoogleMap.mm
+++ b/ios/AirGoogleMaps/AIRGoogleMap.mm
@@ -13,7 +13,9 @@
 #import "AIRGoogleMapPolygon.h"
 #import "AIRGoogleMapPolyline.h"
 #import "AIRGoogleMapCircle.h"
+#if !defined(HAVE_GOOGLE_MAPS_HEATMAP) || HAVE_GOOGLE_MAPS_HEATMAP
 #import "AIRGoogleMapHeatmap.h"
+#endif
 #import "AIRGoogleMapUrlTile.h"
 #import "AIRGoogleMapWMSTile.h"
 #import "AIRGoogleMapOverlay.h"
@@ -280,10 +282,12 @@ id regionAsJSON(MKCoordinateRegion region) {
     AIRGoogleMapOverlay *overlay = (AIRGoogleMapOverlay*)subview;
     overlay.overlay.map = self;
     [self.overlays addObject:overlay];
+#if !defined(HAVE_GOOGLE_MAPS_HEATMAP) || HAVE_GOOGLE_MAPS_HEATMAP
   } else if ([subview isKindOfClass:[AIRGoogleMapHeatmap class]]){
     AIRGoogleMapHeatmap *heatmap = (AIRGoogleMapHeatmap*)subview;
     heatmap.heatmap.map = self;
     [self.heatmaps addObject:heatmap];
+#endif
   } else {
     NSArray<id<RCTComponent>> *childSubviews = [subview reactSubviews];
     for (int i = 0; i < childSubviews.count; i++) {
@@ -330,10 +334,12 @@ id regionAsJSON(MKCoordinateRegion region) {
     AIRGoogleMapOverlay *overlay = (AIRGoogleMapOverlay*)subview;
     overlay.overlay.map = nil;
     [self.overlays removeObject:overlay];
+#if !defined(HAVE_GOOGLE_MAPS_HEATMAP) || HAVE_GOOGLE_MAPS_HEATMAP
   } else if ([subview isKindOfClass:[AIRGoogleMapHeatmap class]]){
     AIRGoogleMapHeatmap *heatmap = (AIRGoogleMapHeatmap*)subview;
     heatmap.heatmap.map = nil;
     [self.heatmaps removeObject:heatmap];
+#endif
   } else {
     NSArray<id<RCTComponent>> *childSubviews = [subview reactSubviews];
     for (int i = 0; i < childSubviews.count; i++) {

--- a/react-native-maps.podspec
+++ b/react-native-maps.podspec
@@ -60,7 +60,9 @@ Pod::Spec.new do |s|
 
            mkdir -p "$DEFINES_DIR"
 
-           if [ -d "$PODS_ROOT/GoogleMaps" ] && [ -d "$PODS_ROOT/Google-Maps-iOS-Utils" ]; then
+           # Also detect the GoogleSPM checkout, or its own script phase
+           # forcing this define can race with this one and flip it back.
+           if ([ -d "$PODS_ROOT/GoogleMaps" ] && [ -d "$PODS_ROOT/Google-Maps-iOS-Utils" ]) || [ -d "$PODS_ROOT/../.spm.pods/packages/.umbrella/.build/checkouts/ios-maps-sdk" ]; then
              echo "#define HAVE_GOOGLE_MAPS 1" > "$DEFINES_FILE"
              echo "✅ Google Maps libraries detected. HAVE_GOOGLE_MAPS defined."
            else

--- a/react-native-maps.podspec
+++ b/react-native-maps.podspec
@@ -133,6 +133,45 @@ Pod::Spec.new do |s|
     install_modules_dependencies(ss)
   end
 
+  # Google Maps via Swift Package Manager (cocoapods-spm), as an alternative
+  # to the Google subspec above. See docs/installation.md for setup.
+  s.subspec 'GoogleSPM' do |ss|
+    ss.source_files = "ios/AirGoogleMaps/**/*.{h,m,mm,swift}"
+    # google-maps-ios-utils versions available via SPM (6.1.3+) rewrote
+    # Heatmap in Swift and dropped the ObjC GMUHeatmapTileLayer header this
+    # wrapper depends on. Excluded here until it's ported to the new API;
+    # the CocoaPods-based Google subspec (pinned to Utils 6.1.0) is
+    # unaffected and keeps Heatmap support.
+    ss.exclude_files = "ios/AirGoogleMaps/AIRGoogleMapHeatmap*.{h,m}"
+    ss.resource_bundles = {
+      'GoogleMapsPrivacy' => ['ios/AirGoogleMaps/Resources/GoogleMapsPrivacy.bundle']
+    }
+    ss.compiler_flags = folly_compiler_flags + ' -DHAVE_GOOGLE_MAPS=1 -DHAVE_GOOGLE_MAPS_UTILS=1 -DHAVE_GOOGLE_MAPS_HEATMAP=0'
+    ss.spm_dependency 'GoogleMaps/GoogleMaps'
+    ss.spm_dependency 'GoogleMapsUtils/GoogleMapsUtils'
+    ss.dependency 'react-native-maps/Generated'
+    ss.dependency 'react-native-maps/Maps'
+    install_modules_dependencies(ss)
+    # cocoapods-spm's checkout path, unlike Xcode's own DerivedData one, is
+    # stable across machines and always exists by the time this builds.
+    ss.pod_target_xcconfig = {
+      'HEADER_SEARCH_PATHS' => '"$(PODS_ROOT)/../.spm.pods/packages/.umbrella/.build/checkouts/google-maps-ios-utils/Sources/GoogleMapsUtilsObjC/include"'
+    }
+    ss.script_phases = [
+      {
+        :name => 'react-native-maps patches (SPM)',
+        :script => %(
+          set -e
+          DEFINES_DIR="${PODS_TARGET_SRCROOT}/ios/AirMaps"
+          DEFINES_FILE="${DEFINES_DIR}/RNMapsDefines.h"
+          mkdir -p "$DEFINES_DIR"
+          echo "#define HAVE_GOOGLE_MAPS 1" > "$DEFINES_FILE"
+        ),
+        :execution_position => :before_compile
+      }
+    ]
+  end
+
   # By default, use the Maps subspec
   s.default_subspec = 'Maps'
 

--- a/react-native-maps.podspec
+++ b/react-native-maps.podspec
@@ -139,16 +139,10 @@ Pod::Spec.new do |s|
   # to the Google subspec above. See docs/installation.md for setup.
   s.subspec 'GoogleSPM' do |ss|
     ss.source_files = "ios/AirGoogleMaps/**/*.{h,m,mm,swift}"
-    # google-maps-ios-utils versions available via SPM (6.1.3+) rewrote
-    # Heatmap in Swift and dropped the ObjC GMUHeatmapTileLayer header this
-    # wrapper depends on. Excluded here until it's ported to the new API;
-    # the CocoaPods-based Google subspec (pinned to Utils 6.1.0) is
-    # unaffected and keeps Heatmap support.
-    ss.exclude_files = "ios/AirGoogleMaps/AIRGoogleMapHeatmap*.{h,m}"
     ss.resource_bundles = {
       'GoogleMapsPrivacy' => ['ios/AirGoogleMaps/Resources/GoogleMapsPrivacy.bundle']
     }
-    ss.compiler_flags = folly_compiler_flags + ' -DHAVE_GOOGLE_MAPS=1 -DHAVE_GOOGLE_MAPS_UTILS=1 -DHAVE_GOOGLE_MAPS_HEATMAP=0'
+    ss.compiler_flags = folly_compiler_flags + ' -DHAVE_GOOGLE_MAPS=1 -DHAVE_GOOGLE_MAPS_UTILS=1 -DHAVE_GOOGLE_MAPS_HEATMAP=1'
     ss.spm_dependency 'GoogleMaps/GoogleMaps'
     ss.spm_dependency 'GoogleMapsUtils/GoogleMapsUtils'
     ss.dependency 'react-native-maps/Generated'
@@ -168,6 +162,30 @@ Pod::Spec.new do |s|
           DEFINES_FILE="${DEFINES_DIR}/RNMapsDefines.h"
           mkdir -p "$DEFINES_DIR"
           echo "#define HAVE_GOOGLE_MAPS 1" > "$DEFINES_FILE"
+
+          # Same @import patch as the Google subspec above, for
+          # cocoapods-spm's checkout instead of the CocoaPods one.
+          echo "🔧 Patching @import GoogleMaps in SPM checkout..."
+          UTILS_INCLUDE_DIR="${PODS_ROOT}/../.spm.pods/packages/.umbrella/.build/checkouts/google-maps-ios-utils/Sources/GoogleMapsUtilsObjC/include"
+          FILES=(
+            "$UTILS_INCLUDE_DIR/GMSMarker+GMUClusteritem.h"
+            "$UTILS_INCLUDE_DIR/GMUGeoJSONParser.h"
+            "$UTILS_INCLUDE_DIR/GMUPolygon.h"
+            "$UTILS_INCLUDE_DIR/GMUWeightedLatLng.h"
+          )
+
+          for file in "${FILES[@]}"; do
+            if [ -f "$file" ]; then
+              if grep -q "@import GoogleMaps;" "$file"; then
+                sed -i '' 's/@import GoogleMaps;/#import <GoogleMaps\\/GoogleMaps.h>/' "$file"
+                echo "✅ Patched: $file"
+              else
+                echo "ℹ️ No @import in: $file"
+              fi
+            else
+              echo "⚠️ Not found: $file"
+            fi
+          done
         ),
         :execution_position => :before_compile
       }


### PR DESCRIPTION
<!--
PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.

**What happens if you SKIP this step?**

Your pull request will NOT be evaluated!

PLEASE NOTE THAT PRs WITHOUT THE TEMPLATE IN PLACE WILL BE CLOSED RIGHT FROM THE START.

Thanks for helping us help you!
-->

### Does any other open PR do the same thing?

Yes, #5880 (@FdClemente), same issue (#5700). Stalled since @salah-ghanim's review in June flagged the manual package-adding step. No commits since.

Tried wiring the SPM package straight to the app target by hand first, no extra gem. Hits `Multiple commands produce`, both the app target and this library's pod target try to embed GoogleMaps resources into the same product on their own. Went with `cocoapods-spm` instead. It resolves packages once into a shared location, so no conflict.

@salah-ghanim commented again on #5700 on June 28, pointing out RN itself doesn't have a finalized SPM spec yet (RFC #0994 still a draft), so fully replacing `Google` (CocoaPods) might be premature. Suggested an opt-in patch instead, for people who need a newer SDK version. `GoogleSPM` goes in alongside `Google` here. `Google` stays untouched.

### What issue is this PR fixing?

Closes #5700.

New `GoogleSPM` subspec resolving GoogleMaps/Google-Maps-iOS-Utils via `cocoapods-spm`, next to the existing `Google` subspec, not replacing it (Google stops shipping new SDK versions to CocoaPods entirely at v11):

```ruby
spm_pkg 'GoogleMaps', :url => 'https://github.com/googlemaps/ios-maps-sdk', :version => '10.15.0'
spm_pkg 'GoogleMapsUtils', :url => 'https://github.com/googlemaps/google-maps-ios-utils', :version => '6.1.3'
pod 'react-native-maps/GoogleSPM', :path => rn_maps_path
```

Also: Heatmap support under GoogleSPM, `AIRGMSServicesProvider` so `AppDelegate` doesn't link the SPM package directly, a build phase copying `GoogleMaps.bundle` into the app (`cocoapods-spm` doesn't carry it over on its own, map tiles silently fail to load without it), `example/` toggles via `USE_GOOGLE_SPM=1` before `pod install`, docs updated.
